### PR TITLE
fix: merge-data.bat set /p 拆成 echo + 空 prompt

### DIFF
--- a/merge-data.bat
+++ b/merge-data.bat
@@ -24,7 +24,7 @@ echo （例如：C:\Users\foo\AppData\Local\Social Auto Upload Web UI）
 echo.
 
 set "SOURCE="
-set /p SOURCE="源数据目录: "
+set /p "SOURCE="
 if errorlevel 1 goto :input_error
 
 if "!SOURCE!"=="" goto :input_empty


### PR DESCRIPTION
旧写法 set /p SOURCE="源数据目录: " 把 prompt 单独用引号包，
但变量名 SOURCE 没在引号内，cmd 切 token 时把
SOURCE="源数据目录 当成半个 token，触发"路径语法错"。

新写法拆成两行：
  echo 源数据目录:
  set /p "SOURCE="  ← 整个 "SOURCE=" 在一个 token

完全规避 prompt 引号问题，set /p 在任何 cmd 环境下都稳定工作。