### PR TITLE
 反馈系统以「一键反馈」菜单的形式接入到桌面应用：卡片形式展示所有反馈数据，支持状态筛选、详情查看、+1 投票、提交新反馈（含附件）

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -786,15 +786,27 @@ def _feedback_headers() -> dict:
 
 @app.route('/api/feedback/list', methods=['GET'])
 def feedback_list():
-    tab = request.args.get('tab', 'active')  # 'active' or 'inactive'
+    """状态筛选：全部 / 待确认 / 处理中 / 已完成 / 已拒绝
+    - 不传 status + 不传 include_all → 仅 status 1+2（默认）
+    - status=1/2/3/4 → 仅对应状态
+    - include_all=true → 全部
+    """
     try:
         page = int(request.args.get('page', 1))
         page_size = min(int(request.args.get('page_size', 20)), 100)
     except ValueError:
         return jsonify({'code': 400, 'message': 'page / page_size 必须是整数', 'data': None}), 400
 
+    status_str = request.args.get('status', '').strip()
+    include_all = request.args.get('include_all', '').lower() == 'true'
+
     params = {'page': page, 'page_size': page_size}
-    if tab == 'inactive':
+    if status_str:
+        try:
+            params['status'] = int(status_str)
+        except ValueError:
+            return jsonify({'code': 400, 'message': 'status 必须是整数 (1-4)', 'data': None}), 400
+    elif include_all:
         params['include_all'] = 'true'
 
     try:
@@ -808,11 +820,6 @@ def feedback_list():
         data = r.json()
     except _requests.RequestException as e:
         return jsonify({'code': 502, 'message': f'反馈系统不可达: {e}', 'data': None}), 502
-
-    if tab == 'inactive':
-        items = [x for x in data.get('data', {}).get('list', []) if x.get('status') in (3, 4)]
-        data['data']['list'] = items
-        data['data']['total'] = len(items)
 
     # attachment.file_url 从相对路径改写为绝对 URL
     for item in data.get('data', {}).get('list', []):

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,4 +1,6 @@
 import asyncio
+import hashlib
+import hmac
 import json
 import os
 import sqlite3
@@ -17,7 +19,13 @@ BACKEND_DIR = Path(__file__).parent.resolve()
 if str(BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(BACKEND_DIR))
 
-from conf import BASE_DIR
+from conf import (
+    BASE_DIR,
+    FEEDBACK_API_BASE_URL,
+    FEEDBACK_APP_KEY,
+    FEEDBACK_APP_SECRET,
+    FEEDBACK_API_TIMEOUT,
+)
 from util._logger import get_channel_logger
 
 logger = get_channel_logger("backend")
@@ -799,3 +807,13 @@ if __name__ == "__main__":
     from waitress import serve
     os.environ["SAU_PORT"] = str(port)
     serve(app, host="0.0.0.0", port=port)
+
+
+# ── 反馈系统代理（HMAC 签名由后端完成，前端永不接触 app_secret）──
+def _feedback_sign(timestamp_ms: str, app_key: str = None, app_secret: str = None) -> str:
+    if app_key is None:
+        app_key = FEEDBACK_APP_KEY
+    if app_secret is None:
+        app_secret = FEEDBACK_APP_SECRET
+    msg = f"{app_key}{timestamp_ms}{app_secret}".encode('utf-8')
+    return hmac.new(app_secret.encode('utf-8'), msg, hashlib.sha256).hexdigest()

--- a/backend/app.py
+++ b/backend/app.py
@@ -852,6 +852,33 @@ def feedback_submit():
         return jsonify({'code': 502, 'message': f'反馈系统不可达: {e}', 'data': None}), 502
 
 
+@app.route('/api/feedback/vote', methods=['POST'])
+def feedback_vote():
+    body = request.get_json(silent=True) or {}
+    fb_id = body.get('id')
+    email = (body.get('email') or '').strip()
+    if not fb_id or not email:
+        return jsonify({'code': 400, 'message': 'id 和 email 必填', 'data': None}), 400
+
+    ts = str(int(time.time() * 1000))
+    headers = {
+        'X-App-Key': FEEDBACK_APP_KEY,
+        'X-Timestamp': ts,
+        'X-Sign': _feedback_sign(ts),
+    }
+
+    try:
+        r = _requests.post(
+            f"{FEEDBACK_API_BASE_URL}/api/v1/feedback/{fb_id}/vote",
+            json={'email': email},
+            headers=headers,
+            timeout=FEEDBACK_API_TIMEOUT,
+        )
+        return (r.json(), r.status_code)
+    except _requests.RequestException as e:
+        return jsonify({'code': 502, 'message': f'反馈系统不可达: {e}', 'data': None}), 502
+
+
 # ── Server entry ────────────────────────────────────────────
 
 def find_available_port(start_port=5409, max_attempts=10):

--- a/backend/app.py
+++ b/backend/app.py
@@ -821,6 +821,37 @@ def feedback_list():
     return jsonify(data)
 
 
+@app.route('/api/feedback/submit', methods=['POST'])
+def feedback_submit():
+    email = request.form.get('email', '').strip()
+    content = request.form.get('content', '').strip()
+    if not email or not content:
+        return jsonify({'code': 400, 'message': '邮箱和内容必填', 'data': None}), 400
+
+    files = []
+    for f in request.files.getlist('files'):
+        files.append(('files', (f.filename, f.stream, f.mimetype)))
+
+    ts = str(int(time.time() * 1000))
+    headers = {
+        'X-App-Key': FEEDBACK_APP_KEY,
+        'X-Timestamp': ts,
+        'X-Sign': _feedback_sign(ts),
+    }
+
+    try:
+        r = _requests.post(
+            f"{FEEDBACK_API_BASE_URL}/api/v1/feedback",
+            data={'email': email, 'content': content},
+            files=files,
+            headers=headers,
+            timeout=FEEDBACK_API_TIMEOUT,
+        )
+        return (r.json(), r.status_code)
+    except _requests.RequestException as e:
+        return jsonify({'code': 502, 'message': f'反馈系统不可达: {e}', 'data': None}), 502
+
+
 # ── Server entry ────────────────────────────────────────────
 
 def find_available_port(start_port=5409, max_attempts=10):

--- a/backend/app.py
+++ b/backend/app.py
@@ -64,6 +64,7 @@ logger.info(f"[Startup] Python {sys.version} starting...")
 logger.info(f"[Startup] Script: {__file__}")
 logger.info(f"[Startup] SAU_PORT={os.environ.get('SAU_PORT')}, SAU_DATA_DIR={os.environ.get('SAU_DATA_DIR')}")
 from impl.registry import get_platform
+from impl.settings import read_settings
 
 app = Flask(__name__)
 CORS(app)
@@ -784,6 +785,12 @@ def _feedback_headers() -> dict:
     }
 
 
+def _get_feedback_email() -> str:
+    """从 settings 表读 feedbackEmail（用户全局邮箱）。空字符串表示未配置。"""
+    val = read_settings().get('feedbackEmail')
+    return (val or '').strip() if isinstance(val, str) else ''
+
+
 @app.route('/api/feedback/list', methods=['GET'])
 def feedback_list():
     """状态筛选：全部 / 待确认 / 处理中 / 已完成 / 已拒绝
@@ -809,6 +816,11 @@ def feedback_list():
     elif include_all:
         params['include_all'] = 'true'
 
+    # 从 settings 表读用户邮箱，作为 metoo 计算依据
+    viewer_email = _get_feedback_email()
+    if viewer_email:
+        params['email'] = viewer_email
+
     try:
         r = _requests.get(
             f"{FEEDBACK_API_BASE_URL}/api/v1/feedback",
@@ -832,10 +844,11 @@ def feedback_list():
 
 @app.route('/api/feedback/submit', methods=['POST'])
 def feedback_submit():
-    email = request.form.get('email', '').strip()
     content = request.form.get('content', '').strip()
+    # 邮箱优先取表单（覆盖场景），否则从 settings 读
+    email = request.form.get('email', '').strip() or _get_feedback_email()
     if not email or not content:
-        return jsonify({'code': 400, 'message': '邮箱和内容必填', 'data': None}), 400
+        return jsonify({'code': 400, 'message': '邮箱和内容必填；如未配置邮箱请先在设置页填写', 'data': None}), 400
 
     files = []
     for f in request.files.getlist('files'):
@@ -858,9 +871,10 @@ def feedback_submit():
 def feedback_vote():
     body = request.get_json(silent=True) or {}
     fb_id = body.get('id')
-    email = (body.get('email') or '').strip()
+    # 邮箱优先取 body（允许前端临时用别的身份），否则从 settings 读
+    email = (body.get('email') or '').strip() or _get_feedback_email()
     if not fb_id or not email:
-        return jsonify({'code': 400, 'message': 'id 和 email 必填', 'data': None}), 400
+        return jsonify({'code': 400, 'message': 'id 和 email 必填；如未配置邮箱请先在设置页填写', 'data': None}), 400
 
     try:
         r = _requests.post(

--- a/backend/app.py
+++ b/backend/app.py
@@ -763,7 +763,6 @@ def health_check():
 
 
 # ── 反馈系统代理（HMAC 签名由后端完成，前端永不接触 app_secret）──
-# 注意：未来 Tasks 4-5 会追加 submit / vote 路由，统一样式
 
 
 def _feedback_sign(timestamp_ms: str, app_key: str = None, app_secret: str = None) -> str:
@@ -773,6 +772,16 @@ def _feedback_sign(timestamp_ms: str, app_key: str = None, app_secret: str = Non
         app_secret = FEEDBACK_APP_SECRET
     msg = f"{app_key}{timestamp_ms}{app_secret}".encode('utf-8')
     return hmac.new(app_secret.encode('utf-8'), msg, hashlib.sha256).hexdigest()
+
+
+def _feedback_headers() -> dict:
+    """生成带 HMAC 签名的反馈系统请求头。"""
+    ts = str(int(time.time() * 1000))
+    return {
+        'X-App-Key': FEEDBACK_APP_KEY,
+        'X-Timestamp': ts,
+        'X-Sign': _feedback_sign(ts),
+    }
 
 
 @app.route('/api/feedback/list', methods=['GET'])
@@ -788,18 +797,11 @@ def feedback_list():
     if tab == 'inactive':
         params['include_all'] = 'true'
 
-    ts = str(int(time.time() * 1000))
-    headers = {
-        'X-App-Key': FEEDBACK_APP_KEY,
-        'X-Timestamp': ts,
-        'X-Sign': _feedback_sign(ts),
-    }
-
     try:
         r = _requests.get(
             f"{FEEDBACK_API_BASE_URL}/api/v1/feedback",
             params=params,
-            headers=headers,
+            headers=_feedback_headers(),
             timeout=FEEDBACK_API_TIMEOUT,
         )
         r.raise_for_status()
@@ -832,19 +834,12 @@ def feedback_submit():
     for f in request.files.getlist('files'):
         files.append(('files', (f.filename, f.stream, f.mimetype)))
 
-    ts = str(int(time.time() * 1000))
-    headers = {
-        'X-App-Key': FEEDBACK_APP_KEY,
-        'X-Timestamp': ts,
-        'X-Sign': _feedback_sign(ts),
-    }
-
     try:
         r = _requests.post(
             f"{FEEDBACK_API_BASE_URL}/api/v1/feedback",
             data={'email': email, 'content': content},
             files=files,
-            headers=headers,
+            headers=_feedback_headers(),
             timeout=FEEDBACK_API_TIMEOUT,
         )
         return (r.json(), r.status_code)
@@ -860,18 +855,11 @@ def feedback_vote():
     if not fb_id or not email:
         return jsonify({'code': 400, 'message': 'id 和 email 必填', 'data': None}), 400
 
-    ts = str(int(time.time() * 1000))
-    headers = {
-        'X-App-Key': FEEDBACK_APP_KEY,
-        'X-Timestamp': ts,
-        'X-Sign': _feedback_sign(ts),
-    }
-
     try:
         r = _requests.post(
             f"{FEEDBACK_API_BASE_URL}/api/v1/feedback/{fb_id}/vote",
             json={'email': email},
-            headers=headers,
+            headers=_feedback_headers(),
             timeout=FEEDBACK_API_TIMEOUT,
         )
         return (r.json(), r.status_code)

--- a/backend/app.py
+++ b/backend/app.py
@@ -12,6 +12,8 @@ from datetime import datetime
 from pathlib import Path
 from queue import Queue
 
+import requests as _requests
+
 from flask import Flask, Response, g, jsonify, request, send_from_directory
 from flask_cors import CORS
 
@@ -760,6 +762,65 @@ def health_check():
     return jsonify(diag)
 
 
+# ── 反馈系统代理（HMAC 签名由后端完成，前端永不接触 app_secret）──
+# 注意：未来 Tasks 4-5 会追加 submit / vote 路由，统一样式
+
+
+def _feedback_sign(timestamp_ms: str, app_key: str = None, app_secret: str = None) -> str:
+    if app_key is None:
+        app_key = FEEDBACK_APP_KEY
+    if app_secret is None:
+        app_secret = FEEDBACK_APP_SECRET
+    msg = f"{app_key}{timestamp_ms}{app_secret}".encode('utf-8')
+    return hmac.new(app_secret.encode('utf-8'), msg, hashlib.sha256).hexdigest()
+
+
+@app.route('/api/feedback/list', methods=['GET'])
+def feedback_list():
+    tab = request.args.get('tab', 'active')  # 'active' or 'inactive'
+    try:
+        page = int(request.args.get('page', 1))
+        page_size = min(int(request.args.get('page_size', 20)), 100)
+    except ValueError:
+        return jsonify({'code': 400, 'message': 'page / page_size 必须是整数', 'data': None}), 400
+
+    params = {'page': page, 'page_size': page_size}
+    if tab == 'inactive':
+        params['include_all'] = 'true'
+
+    ts = str(int(time.time() * 1000))
+    headers = {
+        'X-App-Key': FEEDBACK_APP_KEY,
+        'X-Timestamp': ts,
+        'X-Sign': _feedback_sign(ts),
+    }
+
+    try:
+        r = _requests.get(
+            f"{FEEDBACK_API_BASE_URL}/api/v1/feedback",
+            params=params,
+            headers=headers,
+            timeout=FEEDBACK_API_TIMEOUT,
+        )
+        r.raise_for_status()
+        data = r.json()
+    except _requests.RequestException as e:
+        return jsonify({'code': 502, 'message': f'反馈系统不可达: {e}', 'data': None}), 502
+
+    if tab == 'inactive':
+        items = [x for x in data.get('data', {}).get('list', []) if x.get('status') in (3, 4)]
+        data['data']['list'] = items
+        data['data']['total'] = len(items)
+
+    # attachment.file_url 从相对路径改写为绝对 URL
+    for item in data.get('data', {}).get('list', []):
+        for att in item.get('attachments') or []:
+            if att.get('file_url', '').startswith('/'):
+                att['file_url'] = FEEDBACK_API_BASE_URL + att['file_url']
+
+    return jsonify(data)
+
+
 # ── Server entry ────────────────────────────────────────────
 
 def find_available_port(start_port=5409, max_attempts=10):
@@ -807,13 +868,3 @@ if __name__ == "__main__":
     from waitress import serve
     os.environ["SAU_PORT"] = str(port)
     serve(app, host="0.0.0.0", port=port)
-
-
-# ── 反馈系统代理（HMAC 签名由后端完成，前端永不接触 app_secret）──
-def _feedback_sign(timestamp_ms: str, app_key: str = None, app_secret: str = None) -> str:
-    if app_key is None:
-        app_key = FEEDBACK_APP_KEY
-    if app_secret is None:
-        app_secret = FEEDBACK_APP_SECRET
-    msg = f"{app_key}{timestamp_ms}{app_secret}".encode('utf-8')
-    return hmac.new(app_secret.encode('utf-8'), msg, hashlib.sha256).hexdigest()

--- a/backend/conf.py
+++ b/backend/conf.py
@@ -12,3 +12,9 @@ for _sub in ["db", "logs", "cookies", "cookiesFile", "uploads", "thumbnails"]:
 # 登录（扫码）必须有头模式，验证/发布可用无头模式
 LOCAL_CHROME_HEADLESS = True
 LOGIN_HEADLESS = False
+
+# 反馈系统对接（密钥可暴露，不影响业务；用户已确认）
+FEEDBACK_API_BASE_URL = os.environ.get('FEEDBACK_API_BASE_URL', 'https://feedback.cjxch.com')
+FEEDBACK_APP_KEY = os.environ.get('FEEDBACK_APP_KEY', 'ak_6de413b0f08587a92df5314806920dbde2f4193b076f7431bacec657')
+FEEDBACK_APP_SECRET = os.environ.get('FEEDBACK_APP_SECRET', 'sk_7aa34a39ad547ec2ccd0fc61f23825b197dbbd3bec565461615961f6ca7c113b52937e19c8f372d39c756ae0b5d9bd1f6514e5895e92d4e5')
+FEEDBACK_API_TIMEOUT = int(os.environ.get('FEEDBACK_API_TIMEOUT', '10'))

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -1,0 +1,28 @@
+"""反馈系统代理的单元测试。"""
+import hmac
+import hashlib
+import sys
+from pathlib import Path
+
+# 让 app.py / conf.py 可被 import
+BACKEND_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BACKEND_DIR))
+
+
+def test_feedback_sign_known_vector():
+    """固定输入产生已知 hex（与文档 §3.3 算法对齐）。"""
+    from app import _feedback_sign
+
+    app_key = "ak_test"
+    app_secret = "sk_test"
+    timestamp = "1717555800000"
+
+    # 期望 = HMAC-SHA256(secret, key+timestamp+secret) hex
+    expected_msg = f"{app_key}{timestamp}{app_secret}".encode('utf-8')
+    expected_sig = hmac.new(app_secret.encode('utf-8'), expected_msg, hashlib.sha256).hexdigest()
+
+    actual = _feedback_sign(timestamp, app_key=app_key, app_secret=app_secret)
+    assert actual == expected_sig
+    # 长度为 64（小写 hex）
+    assert len(actual) == 64
+    assert actual == actual.lower()

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -129,3 +129,57 @@ def test_feedback_list_upstream_5xx_returns_502():
         r = client.get("/api/feedback/list?tab=active")
         assert r.status_code == 502
         assert "反馈系统不可达" in r.get_json()["message"]
+
+
+def test_feedback_submit_missing_fields():
+    """缺 email 或 content 返 400。"""
+    from app import app
+
+    client = app.test_client()
+    r = client.post("/api/feedback/submit", data={"email": "a@b.com"})
+    assert r.status_code == 400
+    assert "必填" in r.get_json()["message"]
+
+    r = client.post("/api/feedback/submit", data={"content": "hello"})
+    assert r.status_code == 400
+
+
+def test_feedback_submit_forwards_files():
+    """multipart 字段和文件都正确转发。"""
+    from app import app
+    import io
+
+    fake_resp = MagicMock()
+    fake_resp.json.return_value = {"code": 200, "data": {"id": 99}}
+    fake_resp.status_code = 200
+    fake_resp.raise_for_status = MagicMock()
+
+    captured = {}
+    def fake_post(url, data, files, headers, timeout):
+        captured["url"] = url
+        captured["data"] = data
+        captured["files"] = files
+        captured["headers"] = headers
+        return fake_resp
+
+    with patch("app._requests.post", side_effect=fake_post):
+        client = app.test_client()
+        r = client.post(
+            "/api/feedback/submit",
+            data={
+                "email": "user@example.com",
+                "content": "应用启动后白屏",
+                "files": (io.BytesIO(b"fake-image-bytes"), "screen.png"),
+            },
+            content_type="multipart/form-data",
+            buffered=True,
+        )
+        assert r.status_code == 200
+        assert captured["data"]["email"] == "user@example.com"
+        assert captured["data"]["content"] == "应用启动后白屏"
+        # 至少 1 个文件被转发
+        assert len(captured["files"]) >= 1
+        # 签名头齐
+        assert "X-Sign" in captured["headers"]
+        # URL 正确
+        assert captured["url"].startswith("https://feedback.cjxch.com/api/v1/feedback")

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -1,6 +1,4 @@
 """反馈系统代理的单元测试。"""
-import hmac
-import hashlib
 import sys
 from pathlib import Path
 
@@ -10,19 +8,124 @@ sys.path.insert(0, str(BACKEND_DIR))
 
 
 def test_feedback_sign_known_vector():
-    """固定输入产生已知 hex（与文档 §3.3 算法对齐）。"""
+    """硬编码已知 hex（用 Python 一次性算好写死的，不是运行公式）。"""
     from app import _feedback_sign
 
-    app_key = "ak_test"
-    app_secret = "sk_test"
-    timestamp = "1717555800000"
+    # 已知向量：HMAC-SHA256("sk_test", "ak_test1717555800000sk_test")
+    # 上述公式算出的 hex 是 64 字符小写：
+    expected = "54875963021a1bb4640e2c87ad7e90125d9ee4ca0e4e797bc8abd80e13cd281f"
 
-    # 期望 = HMAC-SHA256(secret, key+timestamp+secret) hex
-    expected_msg = f"{app_key}{timestamp}{app_secret}".encode('utf-8')
-    expected_sig = hmac.new(app_secret.encode('utf-8'), expected_msg, hashlib.sha256).hexdigest()
-
-    actual = _feedback_sign(timestamp, app_key=app_key, app_secret=app_secret)
-    assert actual == expected_sig
-    # 长度为 64（小写 hex）
+    actual = _feedback_sign("1717555800000", app_key="ak_test", app_secret="sk_test")
+    assert actual == expected
     assert len(actual) == 64
     assert actual == actual.lower()
+
+
+def test_feedback_sign_different_vector():
+    """不同输入应产生不同签名（防止常量被硬编码）。"""
+    from app import _feedback_sign
+    sig1 = _feedback_sign("1000", app_key="k1", app_secret="s1")
+    sig2 = _feedback_sign("2000", app_key="k1", app_secret="s1")
+    sig3 = _feedback_sign("1000", app_key="k2", app_secret="s1")
+    assert sig1 != sig2
+    assert sig1 != sig3
+    assert sig2 != sig3
+
+
+from unittest.mock import patch, MagicMock
+
+
+def test_feedback_list_active_tab():
+    """tab=active 时不传 include_all；原样透传上游响应。"""
+    from app import app
+
+    fake_resp = MagicMock()
+    fake_resp.json.return_value = {
+        "code": 200,
+        "data": {
+            "list": [
+                {"id": 1, "status": 1, "vote_count": 5, "created_at": "2026-06-05T10:00:00+08:00",
+                 "attachments": [{"file_url": "/uploads/x.png"}]}
+            ],
+            "total": 1, "page": 1, "page_size": 20
+        }
+    }
+    fake_resp.raise_for_status = MagicMock()
+
+    captured = {}
+    def fake_get(url, params, headers, timeout):
+        captured["url"] = url
+        captured["params"] = params
+        captured["headers"] = headers
+        return fake_resp
+
+    with patch("app._requests.get", side_effect=fake_get):
+        client = app.test_client()
+        r = client.get("/api/feedback/list?tab=active&page=1&page_size=20")
+        assert r.status_code == 200
+        body = r.get_json()
+        # 透传
+        assert body["data"]["total"] == 1
+        # 不应包含 include_all
+        assert "include_all" not in captured["params"]
+        # URL 指向反馈系统
+        assert captured["url"].startswith("https://feedback.cjxch.com/api/v1/feedback")
+        # 签名头齐
+        assert "X-App-Key" in captured["headers"]
+        assert "X-Timestamp" in captured["headers"]
+        assert "X-Sign" in captured["headers"]
+        assert len(captured["headers"]["X-Sign"]) == 64
+        # file_url 被改写为绝对 URL
+        assert body["data"]["list"][0]["attachments"][0]["file_url"] == "https://feedback.cjxch.com/uploads/x.png"
+
+
+def test_feedback_list_inactive_tab_filters():
+    """tab=inactive 时带 include_all=true 并过滤 status 3/4。"""
+    from app import app
+
+    fake_resp = MagicMock()
+    fake_resp.json.return_value = {
+        "code": 200,
+        "data": {
+            "list": [
+                {"id": 1, "status": 1, "vote_count": 5},  # 活跃 - 应被过滤
+                {"id": 2, "status": 3, "vote_count": 2},  # 已完成 - 保留
+                {"id": 3, "status": 4, "vote_count": 1},  # 已拒绝 - 保留
+                {"id": 4, "status": 2, "vote_count": 0},  # 处理中 - 应被过滤
+            ],
+            "total": 4
+        }
+    }
+    fake_resp.raise_for_status = MagicMock()
+
+    captured = {}
+    def fake_get(url, params, headers, timeout):
+        captured["params"] = params
+        return fake_resp
+
+    with patch("app._requests.get", side_effect=fake_get):
+        client = app.test_client()
+        r = client.get("/api/feedback/list?tab=inactive")
+        assert r.status_code == 200
+        body = r.get_json()
+        # 只剩 status 3/4
+        assert body["data"]["total"] == 2
+        ids = [x["id"] for x in body["data"]["list"]]
+        assert ids == [2, 3]
+        # 带 include_all=true
+        assert captured["params"].get("include_all") == "true"
+
+
+def test_feedback_list_upstream_5xx_returns_502():
+    """上游 5xx 时后端返回 502。"""
+    from app import app
+    import requests as _requests
+
+    fake_resp = MagicMock()
+    fake_resp.raise_for_status.side_effect = _requests.HTTPError("500 Server Error")
+
+    with patch("app._requests.get", return_value=fake_resp):
+        client = app.test_client()
+        r = client.get("/api/feedback/list?tab=active")
+        assert r.status_code == 502
+        assert "反馈系统不可达" in r.get_json()["message"]

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -36,7 +36,7 @@ from unittest.mock import patch, MagicMock
 
 
 def test_feedback_list_no_filter_returns_active():
-    """不传 status/include_all 时原样透传上游响应。"""
+    """不传 status/include_all 时原样透传上游响应；自动带上 settings 里的 email。"""
     from app import app
 
     fake_resp = MagicMock()
@@ -59,25 +59,48 @@ def test_feedback_list_no_filter_returns_active():
         captured["headers"] = headers
         return fake_resp
 
-    with patch("app._requests.get", side_effect=fake_get):
-        client = app.test_client()
-        r = client.get("/api/feedback/list?page=1&page_size=20")
-        assert r.status_code == 200
-        body = r.get_json()
-        # 透传
-        assert body["data"]["total"] == 1
-        # 不应包含 include_all 或 status
-        assert "include_all" not in captured["params"]
-        assert "status" not in captured["params"]
-        # URL 指向反馈系统
-        assert captured["url"].startswith("https://feedback.cjxch.com/api/v1/feedback")
-        # 签名头齐
-        assert "X-App-Key" in captured["headers"]
-        assert "X-Timestamp" in captured["headers"]
-        assert "X-Sign" in captured["headers"]
-        assert len(captured["headers"]["X-Sign"]) == 64
-        # file_url 被改写为绝对 URL
-        assert body["data"]["list"][0]["attachments"][0]["file_url"] == "https://feedback.cjxch.com/uploads/x.png"
+    with patch("app.read_settings", return_value={"feedbackEmail": "viewer@example.com"}):
+        with patch("app._requests.get", side_effect=fake_get):
+            client = app.test_client()
+            r = client.get("/api/feedback/list?page=1&page_size=20")
+            assert r.status_code == 200
+            body = r.get_json()
+            assert body["data"]["total"] == 1
+            # 不应包含 include_all 或 status
+            assert "include_all" not in captured["params"]
+            assert "status" not in captured["params"]
+            # settings 里的 email 自动透传给上游
+            assert captured["params"].get("email") == "viewer@example.com"
+            # URL 指向反馈系统
+            assert captured["url"].startswith("https://feedback.cjxch.com/api/v1/feedback")
+            # 签名头齐
+            assert "X-App-Key" in captured["headers"]
+            assert "X-Timestamp" in captured["headers"]
+            assert "X-Sign" in captured["headers"]
+            assert len(captured["headers"]["X-Sign"]) == 64
+            # file_url 被改写为绝对 URL
+            assert body["data"]["list"][0]["attachments"][0]["file_url"] == "https://feedback.cjxch.com/uploads/x.png"
+
+
+def test_feedback_list_no_email_in_settings():
+    """settings 没 email 时不传 email 给上游（仍能正常返回）。"""
+    from app import app
+
+    fake_resp = MagicMock()
+    fake_resp.json.return_value = {"code": 200, "data": {"list": [], "total": 0}}
+    fake_resp.raise_for_status = MagicMock()
+
+    captured = {}
+    def fake_get(url, params, headers, timeout):
+        captured["params"] = params
+        return fake_resp
+
+    with patch("app.read_settings", return_value={}):
+        with patch("app._requests.get", side_effect=fake_get):
+            client = app.test_client()
+            r = client.get("/api/feedback/list")
+            assert r.status_code == 200
+            assert "email" not in captured["params"]
 
 
 def test_feedback_list_status_filter():
@@ -159,20 +182,70 @@ def test_feedback_list_upstream_5xx_returns_502():
 
 
 def test_feedback_submit_missing_fields():
-    """缺 email 或 content 返 400。"""
+    """缺 email（form + settings 都没有）和 content 返 400。"""
     from app import app
 
-    client = app.test_client()
-    r = client.post("/api/feedback/submit", data={"email": "a@b.com"})
-    assert r.status_code == 400
-    assert "必填" in r.get_json()["message"]
+    # 模拟 settings 表里也没 email
+    with patch("app.read_settings", return_value={}):
+        client = app.test_client()
+        r = client.post("/api/feedback/submit", data={"email": "a@b.com"})
+        assert r.status_code == 400
+        assert "必填" in r.get_json()["message"]
 
-    r = client.post("/api/feedback/submit", data={"content": "hello"})
-    assert r.status_code == 400
+        r = client.post("/api/feedback/submit", data={"content": "hello"})
+        assert r.status_code == 400
+
+
+def test_feedback_submit_uses_settings_email_when_form_empty():
+    """form 没传 email 时，从 settings 表读。"""
+    from app import app
+
+    fake_resp = MagicMock()
+    fake_resp.json.return_value = {"code": 200, "data": {"id": 99}}
+    fake_resp.status_code = 200
+    fake_resp.raise_for_status = MagicMock()
+
+    captured = {}
+    def fake_post(url, data, files, headers, timeout):
+        captured["data"] = data
+        return fake_resp
+
+    with patch("app.read_settings", return_value={"feedbackEmail": "settings@example.com"}):
+        with patch("app._requests.post", side_effect=fake_post):
+            client = app.test_client()
+            r = client.post("/api/feedback/submit", data={"content": "hello"})
+            assert r.status_code == 200
+            assert captured["data"]["email"] == "settings@example.com"
+            assert captured["data"]["content"] == "hello"
+
+
+def test_feedback_submit_form_email_overrides_settings():
+    """form 显式传 email 时覆盖 settings（支持一身份多用场景）。"""
+    from app import app
+
+    fake_resp = MagicMock()
+    fake_resp.json.return_value = {"code": 200, "data": {"id": 99}}
+    fake_resp.status_code = 200
+    fake_resp.raise_for_status = MagicMock()
+
+    captured = {}
+    def fake_post(url, data, files, headers, timeout):
+        captured["data"] = data
+        return fake_resp
+
+    with patch("app.read_settings", return_value={"feedbackEmail": "settings@example.com"}):
+        with patch("app._requests.post", side_effect=fake_post):
+            client = app.test_client()
+            r = client.post(
+                "/api/feedback/submit",
+                data={"email": "override@example.com", "content": "hi"},
+            )
+            assert r.status_code == 200
+            assert captured["data"]["email"] == "override@example.com"
 
 
 def test_feedback_submit_forwards_files():
-    """multipart 字段和文件都正确转发。"""
+    """multipart 文件被转发到上游。"""
     from app import app
     import io
 
@@ -189,40 +262,60 @@ def test_feedback_submit_forwards_files():
         captured["headers"] = headers
         return fake_resp
 
-    with patch("app._requests.post", side_effect=fake_post):
-        client = app.test_client()
-        r = client.post(
-            "/api/feedback/submit",
-            data={
-                "email": "user@example.com",
-                "content": "应用启动后白屏",
-                "files": (io.BytesIO(b"fake-image-bytes"), "screen.png"),
-            },
-            content_type="multipart/form-data",
-            buffered=True,
-        )
-        assert r.status_code == 200
-        assert captured["data"]["email"] == "user@example.com"
-        assert captured["data"]["content"] == "应用启动后白屏"
-        # 至少 1 个文件被转发
-        assert len(captured["files"]) >= 1
-        # 签名头齐
-        assert "X-Sign" in captured["headers"]
-        # URL 正确
-        assert captured["url"].startswith("https://feedback.cjxch.com/api/v1/feedback")
+    with patch("app.read_settings", return_value={"feedbackEmail": "user@example.com"}):
+        with patch("app._requests.post", side_effect=fake_post):
+            client = app.test_client()
+            r = client.post(
+                "/api/feedback/submit",
+                data={
+                    "content": "应用启动后白屏",
+                    "files": (io.BytesIO(b"fake-image-bytes"), "screen.png"),
+                },
+                content_type="multipart/form-data",
+                buffered=True,
+            )
+            assert r.status_code == 200
+            assert captured["data"]["email"] == "user@example.com"
+            assert captured["data"]["content"] == "应用启动后白屏"
+            assert len(captured["files"]) >= 1
+            assert "X-Sign" in captured["headers"]
+            assert captured["url"].startswith("https://feedback.cjxch.com/api/v1/feedback")
 
 
-def test_feedback_vote_missing_fields():
-    """缺 id 或 email 返 400。"""
+def test_feedback_vote_uses_settings_email():
+    """vote 不传 email 时从 settings 读。"""
     from app import app
 
-    client = app.test_client()
-    r = client.post("/api/feedback/vote", json={"id": 1})
-    assert r.status_code == 400
-    r = client.post("/api/feedback/vote", json={"email": "a@b.com"})
-    assert r.status_code == 400
-    r = client.post("/api/feedback/vote", json={})
-    assert r.status_code == 400
+    fake_resp = MagicMock()
+    fake_resp.json.return_value = {"code": 200, "data": None}
+    fake_resp.status_code = 200
+    fake_resp.raise_for_status = MagicMock()
+
+    captured = {}
+    def fake_post(url, json, headers, timeout):
+        captured["url"] = url
+        captured["json"] = json
+        return fake_resp
+
+    with patch("app.read_settings", return_value={"feedbackEmail": "settings@example.com"}):
+        with patch("app._requests.post", side_effect=fake_post):
+            client = app.test_client()
+            r = client.post("/api/feedback/vote", json={"id": 42})
+            assert r.status_code == 200
+            assert captured["url"] == "https://feedback.cjxch.com/api/v1/feedback/42/vote"
+            assert captured["json"] == {"email": "settings@example.com"}
+
+
+def test_feedback_vote_no_email_anywhere_returns_400():
+    """settings 没 email + body 也没 email → 400。"""
+    from app import app
+
+    with patch("app.read_settings", return_value={}):
+        client = app.test_client()
+        r = client.post("/api/feedback/vote", json={"id": 1})
+        assert r.status_code == 400
+        r = client.post("/api/feedback/vote", json={"id": 1, "email": ""})
+        assert r.status_code == 400
 
 
 def test_feedback_vote_forwards():
@@ -241,13 +334,14 @@ def test_feedback_vote_forwards():
         captured["headers"] = headers
         return fake_resp
 
-    with patch("app._requests.post", side_effect=fake_post):
-        client = app.test_client()
-        r = client.post("/api/feedback/vote", json={"id": 42, "email": "voter@example.com"})
-        assert r.status_code == 200
-        assert captured["url"] == "https://feedback.cjxch.com/api/v1/feedback/42/vote"
-        assert captured["json"] == {"email": "voter@example.com"}
-        assert "X-Sign" in captured["headers"]
+    with patch("app.read_settings", return_value={"feedbackEmail": "settings@example.com"}):
+        with patch("app._requests.post", side_effect=fake_post):
+            client = app.test_client()
+            r = client.post("/api/feedback/vote", json={"id": 42, "email": "voter@example.com"})
+            assert r.status_code == 200
+            assert captured["url"] == "https://feedback.cjxch.com/api/v1/feedback/42/vote"
+            assert captured["json"] == {"email": "voter@example.com"}
+            assert "X-Sign" in captured["headers"]
 
 
 def test_feedback_vote_passes_through_400():

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -35,8 +35,8 @@ def test_feedback_sign_different_vector():
 from unittest.mock import patch, MagicMock
 
 
-def test_feedback_list_active_tab():
-    """tab=active 时不传 include_all；原样透传上游响应。"""
+def test_feedback_list_no_filter_returns_active():
+    """不传 status/include_all 时原样透传上游响应。"""
     from app import app
 
     fake_resp = MagicMock()
@@ -61,13 +61,14 @@ def test_feedback_list_active_tab():
 
     with patch("app._requests.get", side_effect=fake_get):
         client = app.test_client()
-        r = client.get("/api/feedback/list?tab=active&page=1&page_size=20")
+        r = client.get("/api/feedback/list?page=1&page_size=20")
         assert r.status_code == 200
         body = r.get_json()
         # 透传
         assert body["data"]["total"] == 1
-        # 不应包含 include_all
+        # 不应包含 include_all 或 status
         assert "include_all" not in captured["params"]
+        assert "status" not in captured["params"]
         # URL 指向反馈系统
         assert captured["url"].startswith("https://feedback.cjxch.com/api/v1/feedback")
         # 签名头齐
@@ -79,8 +80,8 @@ def test_feedback_list_active_tab():
         assert body["data"]["list"][0]["attachments"][0]["file_url"] == "https://feedback.cjxch.com/uploads/x.png"
 
 
-def test_feedback_list_inactive_tab_filters():
-    """tab=inactive 时带 include_all=true 并过滤 status 3/4。"""
+def test_feedback_list_status_filter():
+    """status=2 只传 status 给上游。"""
     from app import app
 
     fake_resp = MagicMock()
@@ -88,12 +89,9 @@ def test_feedback_list_inactive_tab_filters():
         "code": 200,
         "data": {
             "list": [
-                {"id": 1, "status": 1, "vote_count": 5},  # 活跃 - 应被过滤
-                {"id": 2, "status": 3, "vote_count": 2},  # 已完成 - 保留
-                {"id": 3, "status": 4, "vote_count": 1},  # 已拒绝 - 保留
-                {"id": 4, "status": 2, "vote_count": 0},  # 处理中 - 应被过滤
+                {"id": 2, "status": 2, "vote_count": 3},
             ],
-            "total": 4
+            "total": 1
         }
     }
     fake_resp.raise_for_status = MagicMock()
@@ -105,15 +103,44 @@ def test_feedback_list_inactive_tab_filters():
 
     with patch("app._requests.get", side_effect=fake_get):
         client = app.test_client()
-        r = client.get("/api/feedback/list?tab=inactive")
+        r = client.get("/api/feedback/list?status=2")
         assert r.status_code == 200
-        body = r.get_json()
-        # 只剩 status 3/4
-        assert body["data"]["total"] == 2
-        ids = [x["id"] for x in body["data"]["list"]]
-        assert ids == [2, 3]
-        # 带 include_all=true
+        assert captured["params"].get("status") == 2
+        assert "include_all" not in captured["params"]
+
+
+def test_feedback_list_include_all():
+    """include_all=true 不传 status。"""
+    from app import app
+
+    fake_resp = MagicMock()
+    fake_resp.json.return_value = {
+        "code": 200,
+        "data": {"list": [], "total": 0}
+    }
+    fake_resp.raise_for_status = MagicMock()
+
+    captured = {}
+    def fake_get(url, params, headers, timeout):
+        captured["params"] = params
+        return fake_resp
+
+    with patch("app._requests.get", side_effect=fake_get):
+        client = app.test_client()
+        r = client.get("/api/feedback/list?include_all=true")
+        assert r.status_code == 200
         assert captured["params"].get("include_all") == "true"
+        assert "status" not in captured["params"]
+
+
+def test_feedback_list_invalid_status():
+    """status 非整数返 400。"""
+    from app import app
+
+    client = app.test_client()
+    r = client.get("/api/feedback/list?status=abc")
+    assert r.status_code == 400
+    assert "status" in r.get_json()["message"]
 
 
 def test_feedback_list_upstream_5xx_returns_502():
@@ -126,7 +153,7 @@ def test_feedback_list_upstream_5xx_returns_502():
 
     with patch("app._requests.get", return_value=fake_resp):
         client = app.test_client()
-        r = client.get("/api/feedback/list?tab=active")
+        r = client.get("/api/feedback/list")
         assert r.status_code == 502
         assert "反馈系统不可达" in r.get_json()["message"]
 

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -183,3 +183,57 @@ def test_feedback_submit_forwards_files():
         assert "X-Sign" in captured["headers"]
         # URL 正确
         assert captured["url"].startswith("https://feedback.cjxch.com/api/v1/feedback")
+
+
+def test_feedback_vote_missing_fields():
+    """缺 id 或 email 返 400。"""
+    from app import app
+
+    client = app.test_client()
+    r = client.post("/api/feedback/vote", json={"id": 1})
+    assert r.status_code == 400
+    r = client.post("/api/feedback/vote", json={"email": "a@b.com"})
+    assert r.status_code == 400
+    r = client.post("/api/feedback/vote", json={})
+    assert r.status_code == 400
+
+
+def test_feedback_vote_forwards():
+    """正常请求正确转发到 /<id>/vote。"""
+    from app import app
+
+    fake_resp = MagicMock()
+    fake_resp.json.return_value = {"code": 200, "data": None}
+    fake_resp.status_code = 200
+    fake_resp.raise_for_status = MagicMock()
+
+    captured = {}
+    def fake_post(url, json, headers, timeout):
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        return fake_resp
+
+    with patch("app._requests.post", side_effect=fake_post):
+        client = app.test_client()
+        r = client.post("/api/feedback/vote", json={"id": 42, "email": "voter@example.com"})
+        assert r.status_code == 200
+        assert captured["url"] == "https://feedback.cjxch.com/api/v1/feedback/42/vote"
+        assert captured["json"] == {"email": "voter@example.com"}
+        assert "X-Sign" in captured["headers"]
+
+
+def test_feedback_vote_passes_through_400():
+    """上游 4xx（如 already voted）原样透传。"""
+    from app import app
+
+    fake_resp = MagicMock()
+    fake_resp.json.return_value = {"code": 400, "message": "already voted", "data": None}
+    fake_resp.status_code = 400
+    fake_resp.raise_for_status = MagicMock()
+
+    with patch("app._requests.post", return_value=fake_resp):
+        client = app.test_client()
+        r = client.post("/api/feedback/vote", json={"id": 1, "email": "a@b.com"})
+        assert r.status_code == 400
+        assert r.get_json()["message"] == "already voted"

--- a/docs/superpowers/plans/2026-06-06-feedback-menu.md
+++ b/docs/superpowers/plans/2026-06-06-feedback-menu.md
@@ -1,0 +1,1482 @@
+# 一键反馈菜单 + 反馈系统对接 实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在桌面应用内新增「一键反馈」菜单，以卡片形式展示 `https://feedback.cjxch.com` 的反馈数据，支持 Tab 切换（活跃/非活跃）、分页、详情抽屉、+1 投票、提交新反馈；同步调整侧边栏菜单顺序为用户指定的新顺序。
+
+**Architecture:** Flask 后端用 HMAC-SHA256 签名代理转发到 feedback.cjxch.com（前端永不接触 `app_secret`）。Vue 前端新增 `Feedback.vue`，通过 `/api/feedback/*` 调用后端。后端单文件追加 3 个路由 + 1 个签名工具，前端新增 1 个 API 模块 + 1 个视图 + 菜单/路由接入 + Settings 加一个邮箱字段。
+
+**Tech Stack:** Python 3 + Flask（已有 `requests==2.32.3`）、Vue 3 + Element Plus（已有 axios + `@/utils/request`）、pytest（项目已有 `backend/test_*.py` 使用模式）
+
+---
+
+## 文件结构
+
+```
+backend/
+├── conf.py                                          # 修改：追加 3 个配置项
+├── app.py                                           # 修改：末尾追加 3 路由 + _feedback_sign
+└── tests/
+    ├── __init__.py                                  # 新建（空文件）
+    └── test_feedback.py                             # 新建：签名 + 3 路由的 pytest
+
+frontend/src/
+├── api/
+│   ├── index.js                                     # 修改：export * from './feedback'
+│   └── feedback.js                                  # 新建：3 个 API 函数
+├── views/
+│   ├── Feedback.vue                                 # 新建：主页面（Tab + 卡片 + 抽屉 + 提交对话框）
+│   └── Settings.vue                                 # 修改：末尾追加「反馈系统」section
+├── App.vue                                          # 修改：navItems 调整顺序 + 新增第 10 项
+└── router/
+    └── index.js                                     # 修改：加 /feedback 路由
+```
+
+总计：1 个修改 + 3 个新建（后端），4 个修改 + 1 个新建（前端）。
+
+---
+
+## Task 1: 后端配置项（conf.py）
+
+**Files:**
+- Modify: `backend/conf.py:1-14`
+
+- [ ] **Step 1: 在 conf.py 末尾追加配置项**
+
+文件末尾（`FEEDBACK_API_TIMEOUT` 之前已存在的最后一个 import 之后）追加：
+
+```python
+# 反馈系统对接（密钥可暴露，不影响业务；用户已确认）
+FEEDBACK_API_BASE_URL = os.environ.get('FEEDBACK_API_BASE_URL', 'https://feedback.cjxch.com')
+FEEDBACK_APP_KEY = os.environ.get('FEEDBACK_APP_KEY', 'ak_6de413b0f08587a92df5314806920dbde2f4193b076f7431bacec657')
+FEEDBACK_APP_SECRET = os.environ.get('FEEDBACK_APP_SECRET', 'sk_7aa34a39ad547ec2ccd0fc61f23825b197dbbd3bec565461615961f6ca7c113b52937e19c8f372d39c756ae0b5d9bd1f6514e5895e92d4e5')
+FEEDBACK_API_TIMEOUT = int(os.environ.get('FEEDBACK_API_TIMEOUT', '10'))
+```
+
+- [ ] **Step 2: 验证导入不报错**
+
+Run:
+```bash
+cd /home/czy/workspace/ai/social-auto-upload-web-ui/backend && python -c "from conf import FEEDBACK_API_BASE_URL, FEEDBACK_APP_KEY, FEEDBACK_APP_SECRET, FEEDBACK_API_TIMEOUT; print(FEEDBACK_API_BASE_URL); print(len(FEEDBACK_APP_KEY)); print(len(FEEDBACK_APP_SECRET)); print(FEEDBACK_API_TIMEOUT)"
+```
+
+Expected: 输出 `https://feedback.cjxch.com`、两个非零长度、`10`，无 ImportError。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add backend/conf.py
+git commit -m "feat(backend): 新增反馈系统对接配置项"
+```
+
+---
+
+## Task 2: 后端签名工具函数 `_feedback_sign`（TDD）
+
+**Files:**
+- Create: `backend/tests/__init__.py`
+- Create: `backend/tests/test_feedback.py`
+
+- [ ] **Step 1: 写失败测试 — 签名输出**
+
+`backend/tests/test_feedback.py`:
+
+```python
+"""反馈系统代理的单元测试。"""
+import hmac
+import hashlib
+import sys
+from pathlib import Path
+
+# 让 app.py / conf.py 可被 import
+BACKEND_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BACKEND_DIR))
+
+
+def test_feedback_sign_known_vector():
+    """固定输入产生已知 hex（与文档 §3.3 算法对齐）。"""
+    from app import _feedback_sign
+
+    app_key = "ak_test"
+    app_secret = "sk_test"
+    timestamp = "1717555800000"
+
+    # 期望 = HMAC-SHA256(secret, key+timestamp+secret) hex
+    expected_msg = f"{app_key}{timestamp}{app_secret}".encode('utf-8')
+    expected_sig = hmac.new(app_secret.encode('utf-8'), expected_msg, hashlib.sha256).hexdigest()
+
+    actual = _feedback_sign(timestamp, app_key=app_key, app_secret=app_secret)
+    assert actual == expected_sig
+    # 长度为 64（小写 hex）
+    assert len(actual) == 64
+    assert actual == actual.lower()
+```
+
+为了让测试可独立传入 key/secret，需要让 `_feedback_sign` 接受可选参数。`app.py` 中定义时把这两个值作为默认参数从 conf 读取。
+
+- [ ] **Step 2: 运行测试，确认失败（因为函数还没定义）**
+
+Run:
+```bash
+cd /home/czy/workspace/ai/social-auto-upload-web-ui/backend && python -m pytest tests/test_feedback.py::test_feedback_sign_known_vector -v
+```
+
+Expected: `FAILED` with `ImportError: cannot import name '_feedback_sign' from 'app'`。
+
+- [ ] **Step 3: 在 app.py 末尾（最后一个 `@app.route` 之后）追加签名工具 + HMAC import**
+
+`backend/app.py` 顶部 import 区追加：
+
+```python
+import hmac
+import hashlib
+```
+
+并在文件末尾（最后一个 route 之后）追加：
+
+```python
+# ── 反馈系统代理（HMAC 签名由后端完成，前端永不接触 app_secret）──
+def _feedback_sign(timestamp_ms: str, app_key: str = None, app_secret: str = None) -> str:
+    if app_key is None:
+        app_key = FEEDBACK_APP_KEY
+    if app_secret is None:
+        app_secret = FEEDBACK_APP_SECRET
+    msg = f"{app_key}{timestamp_ms}{app_secret}".encode('utf-8')
+    return hmac.new(app_secret.encode('utf-8'), msg, hashlib.sha256).hexdigest()
+```
+
+注：app.py 顶部目前是 `from conf import BASE_DIR`。要把新增的 4 个常量也带进来，**整行替换**为：
+
+```python
+from conf import (
+    BASE_DIR,
+    FEEDBACK_API_BASE_URL,
+    FEEDBACK_APP_KEY,
+    FEEDBACK_APP_SECRET,
+    FEEDBACK_API_TIMEOUT,
+)
+```
+
+后续 Task 3-5 的代码使用 `FEEDBACK_API_BASE_URL` 等（不带 `conf.` 前缀）。
+
+- [ ] **Step 4: 运行测试，确认通过**
+
+Run:
+```bash
+cd /home/czy/workspace/ai/social-auto-upload-web-ui/backend && python -m pytest tests/test_feedback.py::test_feedback_sign_known_vector -v
+```
+
+Expected: `PASSED`。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add backend/app.py backend/tests/test_feedback.py backend/tests/__init__.py
+git commit -m "feat(backend): 新增 _feedback_sign 签名工具及单元测试"
+```
+
+---
+
+## Task 3: 后端路由 `GET /api/feedback/list`（TDD）
+
+**Files:**
+- Modify: `backend/app.py`（追加路由）
+- Modify: `backend/tests/test_feedback.py`（追加测试）
+
+- [ ] **Step 1: 追加失败测试 — list 路由转发逻辑**
+
+在 `backend/tests/test_feedback.py` 末尾追加：
+
+```python
+from unittest.mock import patch, MagicMock
+
+
+def test_feedback_list_active_tab(monkeypatch):
+    """tab=active 时不传 include_all；原样透传上游响应。"""
+    from app import app
+
+    fake_resp = MagicMock()
+    fake_resp.json.return_value = {
+        "code": 200,
+        "data": {
+            "list": [
+                {"id": 1, "status": 1, "vote_count": 5, "created_at": "2026-06-05T10:00:00+08:00",
+                 "attachments": [{"file_url": "/uploads/x.png"}]}
+            ],
+            "total": 1, "page": 1, "page_size": 20
+        }
+    }
+    fake_resp.raise_for_status = MagicMock()
+
+    captured = {}
+    def fake_get(url, params, headers, timeout):
+        captured["url"] = url
+        captured["params"] = params
+        captured["headers"] = headers
+        return fake_resp
+
+    with patch("app._requests.get", side_effect=fake_get):
+        client = app.test_client()
+        r = client.get("/api/feedback/list?tab=active&page=1&page_size=20")
+        assert r.status_code == 200
+        body = r.get_json()
+        # 透传
+        assert body["data"]["total"] == 1
+        # 不应包含 include_all
+        assert "include_all" not in captured["params"]
+        # URL 指向反馈系统
+        assert captured["url"].startswith("https://feedback.cjxch.com/api/v1/feedback")
+        # 签名头齐
+        assert "X-App-Key" in captured["headers"]
+        assert "X-Timestamp" in captured["headers"]
+        assert "X-Sign" in captured["headers"]
+        assert len(captured["headers"]["X-Sign"]) == 64
+        # file_url 被改写为绝对 URL
+        assert body["data"]["list"][0]["attachments"][0]["file_url"] == "https://feedback.cjxch.com/uploads/x.png"
+
+
+def test_feedback_list_inactive_tab_filters(monkeypatch):
+    """tab=inactive 时带 include_all=true 并过滤 status 3/4。"""
+    from app import app
+
+    fake_resp = MagicMock()
+    fake_resp.json.return_value = {
+        "code": 200,
+        "data": {
+            "list": [
+                {"id": 1, "status": 1, "vote_count": 5},  # 活跃 - 应被过滤
+                {"id": 2, "status": 3, "vote_count": 2},  # 已完成 - 保留
+                {"id": 3, "status": 4, "vote_count": 1},  # 已拒绝 - 保留
+                {"id": 4, "status": 2, "vote_count": 0},  # 处理中 - 应被过滤
+            ],
+            "total": 4
+        }
+    }
+    fake_resp.raise_for_status = MagicMock()
+
+    captured = {}
+    def fake_get(url, params, headers, timeout):
+        captured["params"] = params
+        return fake_resp
+
+    with patch("app._requests.get", side_effect=fake_get):
+        client = app.test_client()
+        r = client.get("/api/feedback/list?tab=inactive")
+        assert r.status_code == 200
+        body = r.get_json()
+        # 只剩 status 3/4
+        assert body["data"]["total"] == 2
+        ids = [x["id"] for x in body["data"]["list"]]
+        assert ids == [2, 3]
+        # 带 include_all=true
+        assert captured["params"].get("include_all") == "true"
+
+
+def test_feedback_list_upstream_5xx_returns_502(monkeypatch):
+    """上游 5xx 时后端返回 502。"""
+    from app import app
+    import requests as _requests
+
+    fake_resp = MagicMock()
+    fake_resp.raise_for_status.side_effect = _requests.HTTPError("500 Server Error")
+
+    with patch("app._requests.get", return_value=fake_resp):
+        client = app.test_client()
+        r = client.get("/api/feedback/list?tab=active")
+        assert r.status_code == 502
+        assert "反馈系统不可达" in r.get_json()["message"]
+```
+
+- [ ] **Step 2: 运行测试，确认失败**
+
+Run:
+```bash
+cd /home/czy/workspace/ai/social-auto-upload-web-ui/backend && python -m pytest tests/test_feedback.py -v -k "list"
+```
+
+Expected: 3 个 `FAILED`（路由未定义 → 404）。
+
+- [ ] **Step 3: 实现 list 路由**
+
+在 `backend/app.py` 末尾（紧跟 `_feedback_sign` 之后）追加：
+
+```python
+@app.route('/api/feedback/list', methods=['GET'])
+def feedback_list():
+    tab = request.args.get('tab', 'active')  # 'active' or 'inactive'
+    try:
+        page = int(request.args.get('page', 1))
+        page_size = min(int(request.args.get('page_size', 20)), 100)
+    except ValueError:
+        return jsonify({'code': 400, 'message': 'page / page_size 必须是整数', 'data': None}), 400
+
+    params = {'page': page, 'page_size': page_size}
+    if tab == 'inactive':
+        params['include_all'] = 'true'
+
+    ts = str(int(time.time() * 1000))
+    headers = {
+        'X-App-Key': FEEDBACK_APP_KEY,
+        'X-Timestamp': ts,
+        'X-Sign': _feedback_sign(ts),
+    }
+
+    try:
+        r = _requests.get(
+            f"{FEEDBACK_API_BASE_URL}/api/v1/feedback",
+            params=params,
+            headers=headers,
+            timeout=FEEDBACK_API_TIMEOUT,
+        )
+        r.raise_for_status()
+        data = r.json()
+    except _requests.RequestException as e:
+        return jsonify({'code': 502, 'message': f'反馈系统不可达: {e}', 'data': None}), 502
+
+    if tab == 'inactive':
+        items = [x for x in data.get('data', {}).get('list', []) if x.get('status') in (3, 4)]
+        data['data']['list'] = items
+        data['data']['total'] = len(items)
+
+    # attachment.file_url 从相对路径改写为绝对 URL
+    for item in data.get('data', {}).get('list', []):
+        for att in item.get('attachments') or []:
+            if att.get('file_url', '').startswith('/'):
+                att['file_url'] = FEEDBACK_API_BASE_URL + att['file_url']
+
+    return jsonify(data)
+```
+
+确认 `time` 已在 app.py 顶部 import（看 app.py 第 6-15 行，已在 Task 2 时确认存在 `import time`）。如未存在则补：`import time`。
+
+- [ ] **Step 4: 运行测试，确认通过**
+
+Run:
+```bash
+cd /home/czy/workspace/ai/social-auto-upload-web-ui/backend && python -m pytest tests/test_feedback.py -v -k "list"
+```
+
+Expected: 3 个 `PASSED`。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add backend/app.py backend/tests/test_feedback.py
+git commit -m "feat(backend): 实现 GET /api/feedback/list 路由及测试"
+```
+
+---
+
+## Task 4: 后端路由 `POST /api/feedback/submit`（TDD）
+
+**Files:**
+- Modify: `backend/app.py`
+- Modify: `backend/tests/test_feedback.py`
+
+- [ ] **Step 1: 追加失败测试**
+
+在 `backend/tests/test_feedback.py` 末尾追加：
+
+```python
+def test_feedback_submit_missing_fields():
+    """缺 email 或 content 返 400。"""
+    from app import app
+
+    client = app.test_client()
+    r = client.post("/api/feedback/submit", data={"email": "a@b.com"})
+    assert r.status_code == 400
+    assert "必填" in r.get_json()["message"]
+
+    r = client.post("/api/feedback/submit", data={"content": "hello"})
+    assert r.status_code == 400
+
+
+def test_feedback_submit_forwards_files(monkeypatch):
+    """multipart 字段和文件都正确转发。"""
+    from app import app
+    import io
+
+    fake_resp = MagicMock()
+    fake_resp.json.return_value = {"code": 200, "data": {"id": 99}}
+    fake_resp.status_code = 200
+    fake_resp.raise_for_status = MagicMock()
+
+    captured = {}
+    def fake_post(url, data, files, headers, timeout):
+        captured["url"] = url
+        captured["data"] = data
+        captured["files"] = files
+        captured["headers"] = headers
+        return fake_resp
+
+    with patch("app._requests.post", side_effect=fake_post):
+        client = app.test_client()
+        r = client.post(
+            "/api/feedback/submit",
+            data={
+                "email": "user@example.com",
+                "content": "应用启动后白屏",
+            },
+            content_type="multipart/form-data",
+            buffered=True,
+        )
+        # Flask test client 不直接接受 files+data 一起传，单独走上传
+        # 走上传路径
+        r2 = client.post(
+            "/api/feedback/submit",
+            data={
+                "email": "user@example.com",
+                "content": "应用启动后白屏",
+                "files": (io.BytesIO(b"fake-image-bytes"), "screen.png"),
+            },
+            content_type="multipart/form-data",
+            buffered=True,
+        )
+        assert r2.status_code == 200
+        assert captured["data"]["email"] == "user@example.com"
+        assert captured["data"]["content"] == "应用启动后白屏"
+        # 至少 1 个文件被转发
+        assert len(captured["files"]) >= 1
+        # 签名头齐
+        assert "X-Sign" in captured["headers"]
+        # URL 正确
+        assert captured["url"].startswith("https://feedback.cjxch.com/api/v1/feedback")
+```
+
+- [ ] **Step 2: 运行测试，确认失败**
+
+Run:
+```bash
+cd /home/czy/workspace/ai/social-auto-upload-web-ui/backend && python -m pytest tests/test_feedback.py -v -k "submit"
+```
+
+Expected: 2 个 `FAILED`（路由未注册 → 405 或 404）。
+
+- [ ] **Step 3: 实现 submit 路由**
+
+在 `backend/app.py` 末尾追加：
+
+```python
+@app.route('/api/feedback/submit', methods=['POST'])
+def feedback_submit():
+    email = request.form.get('email', '').strip()
+    content = request.form.get('content', '').strip()
+    if not email or not content:
+        return jsonify({'code': 400, 'message': '邮箱和内容必填', 'data': None}), 400
+
+    files = []
+    for f in request.files.getlist('files'):
+        files.append(('files', (f.filename, f.stream, f.mimetype)))
+
+    ts = str(int(time.time() * 1000))
+    headers = {
+        'X-App-Key': FEEDBACK_APP_KEY,
+        'X-Timestamp': ts,
+        'X-Sign': _feedback_sign(ts),
+    }
+
+    try:
+        r = _requests.post(
+            f"{FEEDBACK_API_BASE_URL}/api/v1/feedback",
+            data={'email': email, 'content': content},
+            files=files,
+            headers=headers,
+            timeout=FEEDBACK_API_TIMEOUT,
+        )
+        return (r.json(), r.status_code)
+    except _requests.RequestException as e:
+        return jsonify({'code': 502, 'message': f'反馈系统不可达: {e}', 'data': None}), 502
+```
+
+- [ ] **Step 4: 运行测试，确认通过**
+
+Run:
+```bash
+cd /home/czy/workspace/ai/social-auto-upload-web-ui/backend && python -m pytest tests/test_feedback.py -v -k "submit"
+```
+
+Expected: 2 个 `PASSED`。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add backend/app.py backend/tests/test_feedback.py
+git commit -m "feat(backend): 实现 POST /api/feedback/submit 路由及测试"
+```
+
+---
+
+## Task 5: 后端路由 `POST /api/feedback/vote`（TDD）
+
+**Files:**
+- Modify: `backend/app.py`
+- Modify: `backend/tests/test_feedback.py`
+
+- [ ] **Step 1: 追加失败测试**
+
+在 `backend/tests/test_feedback.py` 末尾追加：
+
+```python
+def test_feedback_vote_missing_fields():
+    """缺 id 或 email 返 400。"""
+    from app import app
+
+    client = app.test_client()
+    r = client.post("/api/feedback/vote", json={"id": 1})
+    assert r.status_code == 400
+    r = client.post("/api/feedback/vote", json={"email": "a@b.com"})
+    assert r.status_code == 400
+    r = client.post("/api/feedback/vote", json={})
+    assert r.status_code == 400
+
+
+def test_feedback_vote_forwards(monkeypatch):
+    """正常请求正确转发到 /<id>/vote。"""
+    from app import app
+
+    fake_resp = MagicMock()
+    fake_resp.json.return_value = {"code": 200, "data": None}
+    fake_resp.status_code = 200
+    fake_resp.raise_for_status = MagicMock()
+
+    captured = {}
+    def fake_post(url, json, headers, timeout):
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        return fake_resp
+
+    with patch("app._requests.post", side_effect=fake_post):
+        client = app.test_client()
+        r = client.post("/api/feedback/vote", json={"id": 42, "email": "voter@example.com"})
+        assert r.status_code == 200
+        assert captured["url"] == "https://feedback.cjxch.com/api/v1/feedback/42/vote"
+        assert captured["json"] == {"email": "voter@example.com"}
+        assert "X-Sign" in captured["headers"]
+
+
+def test_feedback_vote_passes_through_400(monkeypatch):
+    """上游 4xx（如 already voted）原样透传。"""
+    from app import app
+
+    fake_resp = MagicMock()
+    fake_resp.json.return_value = {"code": 400, "message": "already voted", "data": None}
+    fake_resp.status_code = 400
+    fake_resp.raise_for_status = MagicMock()
+
+    with patch("app._requests.post", return_value=fake_resp):
+        client = app.test_client()
+        r = client.post("/api/feedback/vote", json={"id": 1, "email": "a@b.com"})
+        assert r.status_code == 400
+        assert r.get_json()["message"] == "already voted"
+```
+
+- [ ] **Step 2: 运行测试，确认失败**
+
+Run:
+```bash
+cd /home/czy/workspace/ai/social-auto-upload-web-ui/backend && python -m pytest tests/test_feedback.py -v -k "vote"
+```
+
+Expected: 3 个 `FAILED`（路由未注册）。
+
+- [ ] **Step 3: 实现 vote 路由**
+
+在 `backend/app.py` 末尾追加：
+
+```python
+@app.route('/api/feedback/vote', methods=['POST'])
+def feedback_vote():
+    body = request.get_json(silent=True) or {}
+    fb_id = body.get('id')
+    email = (body.get('email') or '').strip()
+    if not fb_id or not email:
+        return jsonify({'code': 400, 'message': 'id 和 email 必填', 'data': None}), 400
+
+    ts = str(int(time.time() * 1000))
+    headers = {
+        'X-App-Key': FEEDBACK_APP_KEY,
+        'X-Timestamp': ts,
+        'X-Sign': _feedback_sign(ts),
+    }
+
+    try:
+        r = _requests.post(
+            f"{FEEDBACK_API_BASE_URL}/api/v1/feedback/{fb_id}/vote",
+            json={'email': email},
+            headers=headers,
+            timeout=FEEDBACK_API_TIMEOUT,
+        )
+        return (r.json(), r.status_code)
+    except _requests.RequestException as e:
+        return jsonify({'code': 502, 'message': f'反馈系统不可达: {e}', 'data': None}), 502
+```
+
+- [ ] **Step 4: 运行测试，确认通过**
+
+Run:
+```bash
+cd /home/czy/workspace/ai/social-auto-upload-web-ui/backend && python -m pytest tests/test_feedback.py -v
+```
+
+Expected: 所有测试（9 个：1 sign + 3 list + 2 submit + 3 vote）`PASSED`。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add backend/app.py backend/tests/test_feedback.py
+git commit -m "feat(backend): 实现 POST /api/feedback/vote 路由及测试"
+```
+
+---
+
+## Task 6: 前端 API 模块 `frontend/src/api/feedback.js`
+
+**Files:**
+- Create: `frontend/src/api/feedback.js`
+
+- [ ] **Step 1: 创建文件**
+
+```javascript
+import { http } from '@/utils/request'
+
+export function listFeedback({ tab, page = 1, pageSize = 20 }) {
+  return http.get('/api/feedback/list', {
+    params: { tab, page, page_size: pageSize }
+  })
+}
+
+export function submitFeedback(formData) {
+  return http.upload('/api/feedback/submit', formData)
+}
+
+export function voteFeedback({ id, email }) {
+  return http.post('/api/feedback/vote', { id, email })
+}
+```
+
+注：`http.upload` 是 `@/utils/request.js` 已有的方法（`request.post(formData, { headers: { 'Content-Type': 'multipart/form-data' } })`），专门处理 multipart。
+
+- [ ] **Step 2: 在 `frontend/src/api/index.js` 添加 export**
+
+修改文件末尾（现有 3 个 `export *` 之后）追加：
+
+```javascript
+export * from './feedback'
+```
+
+- [ ] **Step 3: 验证不报错**
+
+```bash
+cd /home/czy/workspace/ai/social-auto-upload-web-ui/frontend && npx vite build --mode development 2>&1 | head -30
+```
+
+Expected: 无模块解析错误。如果只想快速 lint 一下：`node -e "import('./src/api/feedback.js').then(()=>console.log('ok'))"` 不行（Vite/ESM 路径），直接走 build。
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add frontend/src/api/feedback.js frontend/src/api/index.js
+git commit -m "feat(frontend): 新增 feedback API 模块"
+```
+
+---
+
+## Task 7: 前端 Settings 加「反馈系统邮箱」字段
+
+**Files:**
+- Modify: `frontend/src/views/Settings.vue`
+
+- [ ] **Step 1: 在 Settings.vue 末尾的 `</template>` 之前插入反馈系统 section**
+
+定位：在 `</div>` 关闭最后一个 `settings-card` 之后、`<div class="save-bar">` 之前，插入新 section。可以通过搜索 `<div class="save-bar">` 找到。
+
+在 `<div class="save-bar">` 这一行**之前**插入：
+
+```html
+    <!-- 反馈系统 -->
+    <div class="settings-card">
+      <h3 class="card-title">
+        <el-icon class="title-icon"><ChatDotRound /></el-icon>
+        反馈系统
+      </h3>
+      <div class="setting-row">
+        <div class="setting-info">
+          <span class="setting-label">反馈邮箱</span>
+          <span class="setting-desc">用于在「一键反馈」菜单提交反馈和投票。不填将无法使用这些功能</span>
+        </div>
+        <div class="setting-control">
+          <el-input
+            v-model="settings.feedbackEmail"
+            placeholder="your@email.com"
+            style="width: 300px"
+            clearable
+          />
+        </div>
+      </div>
+    </div>
+```
+
+- [ ] **Step 2: 在 `<script setup>` 区顶部 import ChatDotRound**
+
+定位 `import { ref, reactive, onMounted } from 'vue'` 附近的 icon 导入区（搜索 `from '@element-plus/icons-vue'`）。
+
+在该行后追加 `ChatDotRound`：
+
+```javascript
+import { ChatDotRound } from '@element-plus/icons-vue'
+```
+
+- [ ] **Step 3: 在 reactive 的 `settings` 对象里加 `feedbackEmail` 字段**
+
+定位 `const settings = reactive({` 块，在最后一个属性之后追加 `feedbackEmail: ''`。
+
+- [ ] **Step 4: 在 onMounted 加载逻辑里加 localStorage 读取**
+
+定位 `onMounted(() => {` 块。
+
+在该函数内、所有 `if (res.data.xxx !== undefined) settings.xxx = res.data.xxx` 赋值行之后，追加 localStorage 兜底读取（后端 settings API 不返回此字段，靠前端 localStorage）：
+
+```javascript
+      const savedEmail = localStorage.getItem('global_user_email')
+      if (savedEmail && !settings.feedbackEmail) {
+        settings.feedbackEmail = savedEmail
+      }
+```
+
+- [ ] **Step 5: 在 handleSave 函数里加 localStorage 写入**
+
+定位 `handleSave`（搜索 `async function handleSave` 或 `:disabled="saving" @click="handleSave"`）。
+
+在该函数最后一行（通常是 `ElMessage.success`）之前，加：
+
+```javascript
+      localStorage.setItem('global_user_email', settings.feedbackEmail || '')
+```
+
+- [ ] **Step 6: 验证 build 通过**
+
+```bash
+cd /home/czy/workspace/ai/social-auto-upload-web-ui/frontend && npx vite build --mode development 2>&1 | tail -10
+```
+
+Expected: 成功，无错误。
+
+- [ ] **Step 7: 提交**
+
+```bash
+git add frontend/src/views/Settings.vue
+git commit -m "feat(frontend): Settings 加反馈系统邮箱字段"
+```
+
+---
+
+## Task 8: 前端 `Feedback.vue` 主页面（核心 UI）
+
+**Files:**
+- Create: `frontend/src/views/Feedback.vue`
+
+- [ ] **Step 1: 创建文件 — 模板区**
+
+```vue
+<template>
+  <div class="feedback-page">
+    <div class="page-header">
+      <div>
+        <h1 class="page-title">一键反馈</h1>
+        <p class="page-subtitle">查看、提交、投票反馈，与作者一起改进产品</p>
+      </div>
+      <el-button type="primary" :icon="Plus" @click="openSubmitDialog">提交反馈</el-button>
+    </div>
+
+    <el-tabs v-model="activeTab" @tab-change="handleTabChange">
+      <el-tab-pane :label="`活跃反馈 (${tabCount.active})`" name="active" />
+      <el-tab-pane :label="`非活跃反馈 (${tabCount.inactive})`" name="inactive" />
+    </el-tabs>
+
+    <div v-loading="loading" class="card-grid">
+      <el-empty v-if="!loading && sortedList.length === 0" description="暂无反馈" />
+      <div
+        v-for="fb in sortedList"
+        :key="fb.id"
+        class="feedback-card"
+        @click="openDrawer(fb)"
+      >
+        <div class="card-top">
+          <el-tag :type="statusTagType(fb.status)" size="small">
+            {{ statusLabel(fb.status) }}
+          </el-tag>
+          <span class="vote-count" @click.stop="handleVote(fb)">
+            <el-icon><CaretTop /></el-icon>
+            {{ fb.vote_count || 0 }}
+          </span>
+        </div>
+        <div class="card-content">{{ truncate(fb.content, 80) }}</div>
+        <div class="card-meta">
+          <span class="meta-email">{{ maskEmail(fb.email) }}</span>
+          <span class="meta-time">{{ formatTime(fb.created_at) }}</span>
+        </div>
+        <div v-if="fb.attachments && fb.attachments.length" class="card-attachments">
+          <el-icon><Paperclip /></el-icon>
+          {{ fb.attachments.length }} 个附件
+        </div>
+      </div>
+    </div>
+
+    <div v-if="total > 0" class="pagination-wrapper">
+      <el-pagination
+        v-model:current-page="page"
+        v-model:page-size="pageSize"
+        :page-sizes="[10, 20, 50]"
+        :total="total"
+        layout="total, sizes, prev, pager, next, jumper"
+        @current-change="loadList"
+        @size-change="onSizeChange"
+      />
+    </div>
+
+    <!-- 详情抽屉 -->
+    <el-drawer
+      v-model="drawerVisible"
+      :title="`反馈 #${currentFb?.id || ''}`"
+      size="500px"
+      direction="rtl"
+    >
+      <div v-if="currentFb" class="drawer-content">
+        <el-tag :type="statusTagType(currentFb.status)" size="small">
+          {{ statusLabel(currentFb.status) }}
+        </el-tag>
+        <div v-if="currentFb.assignee" class="drawer-assignee">
+          处理人：{{ currentFb.assignee }}
+        </div>
+        <div class="drawer-time">{{ formatTime(currentFb.created_at) }}</div>
+        <div class="drawer-content-text">{{ currentFb.content }}</div>
+        <div v-if="currentFb.attachments && currentFb.attachments.length" class="drawer-attachments">
+          <h4>附件</h4>
+          <el-image
+            v-for="att in currentFb.attachments"
+            :key="att.id"
+            :src="att.file_url"
+            :preview-src-list="currentFb.attachments.map(a => a.file_url)"
+            :initial-index="0"
+            fit="cover"
+            class="attachment-img"
+          />
+        </div>
+        <div class="drawer-vote">
+          <el-button
+            type="primary"
+            :disabled="votedIds.has(currentFb.id)"
+            @click="handleVote(currentFb)"
+          >
+            <el-icon><CaretTop /></el-icon>
+            {{ votedIds.has(currentFb.id) ? '已支持' : '+1 支持' }}
+            <span v-if="currentFb.vote_count" class="vote-num">{{ currentFb.vote_count }}</span>
+          </el-button>
+        </div>
+      </div>
+    </el-drawer>
+
+    <!-- 提交反馈对话框 -->
+    <el-dialog v-model="submitVisible" title="提交反馈" width="500px">
+      <el-form :model="submitForm" label-width="80px">
+        <el-form-item label="邮箱" required>
+          <el-input v-model="submitForm.email" placeholder="your@email.com" />
+        </el-form-item>
+        <el-form-item label="内容" required>
+          <el-input v-model="submitForm.content" type="textarea" :rows="5" placeholder="详细描述您遇到的问题或建议" />
+        </el-form-item>
+        <el-form-item label="附件">
+          <el-upload
+            :auto-upload="false"
+            :limit="1"
+            :on-change="onFileChange"
+            :on-exceed="onExceed"
+            :on-remove="onFileRemove"
+            accept=".png,.jpg,.jpeg,.gif,.bmp,.webp,.pdf,.doc,.docx,.xlsx,.xls,.pptx,.ppt"
+            list-type="picture"
+          >
+            <el-button :icon="Upload">选择文件 (≤5MB)</el-button>
+            <template #tip>
+              <div class="el-upload__tip">支持图片、PDF、Office 文档，单文件不超过 5MB</div>
+            </template>
+          </el-upload>
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="submitVisible = false">取消</el-button>
+        <el-button type="primary" :loading="submitting" @click="handleSubmit">提交</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+```
+
+- [ ] **Step 2: 添加 `<script setup>` 区**
+
+接在 `</template>` 之后：
+
+```vue
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { Plus, CaretTop, Paperclip, Upload } from '@element-plus/icons-vue'
+import { listFeedback, submitFeedback as apiSubmit, voteFeedback as apiVote } from '@/api/feedback'
+
+const router = useRouter()
+
+const activeTab = ref('active')
+const loading = ref(false)
+const list = ref([])
+const total = ref(0)
+const page = ref(1)
+const pageSize = ref(20)
+const tabCount = ref({ active: 0, inactive: 0 })
+
+const drawerVisible = ref(false)
+const currentFb = ref(null)
+
+const submitVisible = ref(false)
+const submitting = ref(false)
+const submitForm = ref({ email: '', content: '' })
+const submitFile = ref(null)
+
+const votedIds = ref(new Set())
+
+const sortedList = computed(() => {
+  return [...list.value].sort((a, b) => {
+    if ((b.vote_count || 0) !== (a.vote_count || 0)) {
+      return (b.vote_count || 0) - (a.vote_count || 0)
+    }
+    return new Date(b.created_at) - new Date(a.created_at)
+  })
+})
+
+function statusLabel(s) {
+  return { 1: '待确认', 2: '处理中', 3: '已完成', 4: '已拒绝' }[s] || '未知'
+}
+function statusTagType(s) {
+  return { 1: 'warning', 2: 'primary', 3: 'success', 4: 'info' }[s] || 'info'
+}
+function truncate(text, n) {
+  if (!text) return ''
+  return text.length > n ? text.slice(0, n) + '…' : text
+}
+function maskEmail(email) {
+  if (!email) return ''
+  const [user, domain] = email.split('@')
+  if (!domain) return email
+  return user.slice(0, 2) + '***@' + domain
+}
+function formatTime(iso) {
+  if (!iso) return ''
+  const d = new Date(iso)
+  return d.toLocaleString('zh-CN', { hour12: false })
+}
+
+async function loadList() {
+  loading.value = true
+  try {
+    const res = await listFeedback({
+      tab: activeTab.value,
+      page: page.value,
+      pageSize: pageSize.value
+    })
+    list.value = res.data?.list || []
+    total.value = res.data?.total || 0
+  } catch (e) {
+    list.value = []
+    total.value = 0
+  } finally {
+    loading.value = false
+  }
+}
+
+async function loadTabCounts() {
+  // 活跃/非活跃总数都拉一次（小开销，page_size=1 只取 total）
+  try {
+    const [a, i] = await Promise.all([
+      listFeedback({ tab: 'active', page: 1, pageSize: 1 }),
+      listFeedback({ tab: 'inactive', page: 1, pageSize: 1 })
+    ])
+    tabCount.value = {
+      active: a.data?.total || 0,
+      inactive: i.data?.total || 0
+    }
+  } catch (e) {
+    tabCount.value = { active: 0, inactive: 0 }
+  }
+}
+
+function handleTabChange() {
+  page.value = 1
+  loadList()
+}
+function onSizeChange(s) {
+  pageSize.value = s
+  page.value = 1
+  loadList()
+}
+
+function openDrawer(fb) {
+  currentFb.value = fb
+  drawerVisible.value = true
+}
+
+async function handleVote(fb) {
+  const email = localStorage.getItem('global_user_email') || ''
+  if (!email) {
+    await promptForEmail()
+    return
+  }
+  if (votedIds.value.has(fb.id)) return
+  try {
+    await apiVote({ id: fb.id, email })
+    votedIds.value.add(fb.id)
+    fb.vote_count = (fb.vote_count || 0) + 1
+    ElMessage.success('+1 成功')
+  } catch (e) {
+    // 400 already voted - 加入集合
+    if (e.message && e.message.includes('already voted')) {
+      votedIds.value.add(fb.id)
+      ElMessage.warning('您已为此反馈投过票')
+    }
+    // 其他错误已被 request.js 拦截器处理
+  }
+}
+
+async function promptForEmail() {
+  try {
+    await ElMessageBox.confirm(
+      '请前往设置页填写反馈邮箱',
+      '需要邮箱',
+      { confirmButtonText: '去设置', cancelButtonText: '取消', type: 'warning' }
+    )
+    router.push('/settings')
+  } catch (_) {
+    // 用户取消，不操作
+  }
+}
+
+function openSubmitDialog() {
+  submitForm.value = {
+    email: localStorage.getItem('global_user_email') || '',
+    content: ''
+  }
+  submitFile.value = null
+  submitVisible.value = true
+}
+function onFileChange(file) {
+  if (file.size > 5 * 1024 * 1024) {
+    ElMessage.error('文件超过 5MB')
+    submitFile.value = null
+    return false
+  }
+  submitFile.value = file.raw
+}
+function onExceed() {
+  ElMessage.warning('只能上传 1 个文件')
+}
+function onFileRemove() {
+  submitFile.value = null
+}
+
+async function handleSubmit() {
+  const email = submitForm.value.email.trim()
+  const content = submitForm.value.content.trim()
+  if (!email || !content) {
+    ElMessage.error('邮箱和内容必填')
+    return
+  }
+  // 邮箱不匹配全局设置时，自动更新
+  const globalEmail = localStorage.getItem('global_user_email') || ''
+  if (email !== globalEmail) {
+    localStorage.setItem('global_user_email', email)
+  }
+
+  submitting.value = true
+  try {
+    const fd = new FormData()
+    fd.append('email', email)
+    fd.append('content', content)
+    if (submitFile.value) {
+      fd.append('files', submitFile.value)
+    }
+    await apiSubmit(fd)
+    ElMessage.success('提交成功')
+    submitVisible.value = false
+    await loadList()
+    await loadTabCounts()
+  } catch (e) {
+    // 错误已由 request.js 拦截器处理
+  } finally {
+    submitting.value = false
+  }
+}
+
+onMounted(async () => {
+  const email = localStorage.getItem('global_user_email')
+  if (!email) {
+    await promptForEmail()
+  }
+  await loadList()
+  await loadTabCounts()
+})
+</script>
+```
+
+- [ ] **Step 3: 添加 `<style scoped>` 区**
+
+```vue
+<style lang="scss" scoped>
+@use '@/styles/variables.scss' as *;
+
+.feedback-page {
+  padding: 24px 32px;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: 24px;
+}
+
+.page-title {
+  font-size: 24px;
+  font-weight: 700;
+  color: $text-primary;
+  margin-bottom: 4px;
+}
+
+.page-subtitle {
+  font-size: 13px;
+  color: $text-muted;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 16px;
+  min-height: 200px;
+  margin-top: 16px;
+}
+
+.feedback-card {
+  padding: 16px;
+  border-radius: 12px;
+  background: $bg-elevated;
+  border: 1px solid $border;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    border-color: $brand-start;
+    transform: translateY(-2px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  }
+}
+
+.card-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.vote-count {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: #ef4444;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 2px 8px;
+  border-radius: 12px;
+  transition: background 0.2s;
+
+  &:hover {
+    background: rgba(239, 68, 68, 0.1);
+  }
+}
+
+.card-content {
+  font-size: 14px;
+  line-height: 1.6;
+  color: $text-primary;
+  margin-bottom: 12px;
+  word-break: break-word;
+}
+
+.card-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  color: $text-muted;
+  margin-bottom: 8px;
+}
+
+.card-attachments {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: $text-muted;
+}
+
+.pagination-wrapper {
+  display: flex;
+  justify-content: center;
+  padding: 24px 0;
+}
+
+.drawer-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.drawer-assignee {
+  font-size: 13px;
+  color: $text-secondary;
+}
+
+.drawer-time {
+  font-size: 12px;
+  color: $text-muted;
+}
+
+.drawer-content-text {
+  padding: 12px;
+  background: $bg-surface;
+  border-radius: 8px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.drawer-attachments {
+  h4 {
+    font-size: 14px;
+    margin-bottom: 8px;
+    color: $text-primary;
+  }
+  .attachment-img {
+    width: 100px;
+    height: 100px;
+    border-radius: 6px;
+    margin-right: 8px;
+    margin-bottom: 8px;
+  }
+}
+
+.drawer-vote {
+  padding-top: 12px;
+  border-top: 1px solid $border;
+}
+
+.vote-num {
+  margin-left: 6px;
+  padding: 0 8px;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 10px;
+  font-size: 12px;
+}
+
+:deep(.el-tabs__item) {
+  color: $text-secondary;
+}
+:deep(.el-tabs__item.is-active) {
+  color: $brand-start;
+}
+</style>
+```
+
+> 注：样式中 `$text-primary`、`$bg-elevated` 等 SCSS 变量来自 `@/styles/variables.scss`（项目其他页面如 Dashboard.vue、AccountManagement.vue 已使用此模式）。
+
+- [ ] **Step 4: 验证 build 通过**
+
+```bash
+cd /home/czy/workspace/ai/social-auto-upload-web-ui/frontend && npx vite build --mode development 2>&1 | tail -20
+```
+
+Expected: 成功，无错误。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add frontend/src/views/Feedback.vue
+git commit -m "feat(frontend): 实现 Feedback.vue 主页面"
+```
+
+---
+
+## Task 9: 前端 `App.vue` 调整菜单顺序 + 新增第 10 项
+
+**Files:**
+- Modify: `frontend/src/App.vue`
+
+- [ ] **Step 1: 调整 navItems 数组**
+
+定位 `const navItems = [` 块。**完整替换**为：
+
+```javascript
+const navItems = [
+  { path: '/', icon: HomeFilled, title: '仪表盘' },
+  { path: '/account-management', icon: User, title: '账号管理' },
+  { path: '/material-management', icon: Picture, title: '素材管理' },
+  { path: '/publish-center', icon: Upload, title: '视频发布' },
+  { path: '/image-publish', icon: Picture, title: '图文发布' },
+  { path: '/drafts', icon: Document, title: '草稿箱' },
+  { path: '/publish-history', icon: Clock, title: '发布历史' },
+  { path: '/changelog', icon: Notebook, title: '更新日志' },
+  { path: '/author', icon: UserFilled, title: '关于作者' },
+  { path: '/feedback', icon: ChatDotRound, title: '一键反馈' }
+]
+```
+
+- [ ] **Step 2: 在 icon import 行追加 ChatDotRound**
+
+定位 `import { ... } from '@element-plus/icons-vue'`。
+
+在该行末尾 `UserFilled, Document, Notebook` 之后追加 `, ChatDotRound`：
+
+```javascript
+import {
+  HomeFilled, User, Picture, Upload,
+  Clock, Setting, Expand, Fold, UserFilled, Document, Notebook, ChatDotRound
+} from '@element-plus/icons-vue'
+```
+
+- [ ] **Step 3: 验证 build 通过**
+
+```bash
+cd /home/czy/workspace/ai/social-auto-upload-web-ui/frontend && npx vite build --mode development 2>&1 | tail -5
+```
+
+Expected: 成功。
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add frontend/src/App.vue
+git commit -m "feat(frontend): 调整菜单顺序并新增一键反馈入口"
+```
+
+---
+
+## Task 10: 前端 `router/index.js` 加路由
+
+**Files:**
+- Modify: `frontend/src/router/index.js`
+
+- [ ] **Step 1: 在 routes 数组末尾追加**
+
+定位 `const routes = [` 块的最后一个 `}` 元素（Author 路由）之后，逗号后追加：
+
+```javascript
+  { path: '/feedback', name: 'Feedback', component: () => import('../views/Feedback.vue'), meta: { icon: 'ChatDotRound', title: '一键反馈' } }
+```
+
+完整 routes 数组最后两行形如：
+
+```javascript
+  { path: '/author', name: 'Author', component: Author, meta: { icon: 'UserFilled', title: '关于作者', isBottom: true } },
+  { path: '/feedback', name: 'Feedback', component: () => import('../views/Feedback.vue'), meta: { icon: 'ChatDotRound', title: '一键反馈' } }
+```
+
+- [ ] **Step 2: 验证 build 通过**
+
+```bash
+cd /home/czy/workspace/ai/social-auto-upload-web-ui/frontend && npx vite build --mode development 2>&1 | tail -5
+```
+
+Expected: 成功。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add frontend/src/router/index.js
+git commit -m "feat(frontend): 加 /feedback 路由"
+```
+
+---
+
+## Task 11: 手动 e2e 验证
+
+**Files:** 无（仅验证）
+
+- [ ] **Step 1: 启动后端**
+
+```bash
+cd /home/czy/workspace/ai/social-auto-upload-web-ui/backend && python app.py
+```
+
+Expected: 端口 5409 监听中，无报错。如被占用：
+
+```bash
+lsof -i :5409 | grep -v "^COMMAND" | awk '{print $2}' | xargs -r kill -9
+```
+
+- [ ] **Step 2: 启动前端 dev server**
+
+新开终端：
+
+```bash
+cd /home/czy/workspace/ai/social-auto-upload-web-ui/frontend && npm run dev
+```
+
+Expected: Vite 启动，端口 5173 监听。
+
+- [ ] **Step 3: 浏览器验证清单**
+
+打开 `http://localhost:5173`，逐项打勾：
+
+- [ ] 左侧菜单出现「一键反馈」在第 10 项（最底部）
+- [ ] 菜单顺序：仪表盘、账号管理、素材管理、视频发布、图文发布、草稿箱、发布历史、更新日志、关于作者、一键反馈
+- [ ] 点击「一键反馈」进入页面
+- [ ] 若未在 Settings 填邮箱，弹出提示「请前往设置页填写反馈邮箱」并提供「去设置」按钮
+- [ ] 去 Settings 填邮箱，保存
+- [ ] 返回「一键反馈」页面
+- [ ] 列表正常加载（活跃 Tab 显示待确认+处理中的反馈）
+- [ ] 切换到「非活跃反馈」Tab，显示已完成+已拒绝的
+- [ ] 每张卡片显示：状态徽章、内容预览、+1 数、邮箱（脱敏）、创建时间
+- [ ] 卡片按 `vote_count desc, created_at desc` 排序
+- [ ] 点击卡片，右侧抽屉显示完整内容
+- [ ] 抽屉内点击「+1 支持」，按钮变「已支持」，+1 数字 +1
+- [ ] 再次点不会重复 +1
+- [ ] 页面右上角点「提交反馈」，弹对话框
+- [ ] 邮箱已自动填充全局邮箱
+- [ ] 填内容，可选附件，点「提交」
+- [ ] 关闭对话框，列表自动刷新，新反馈出现在最前面
+- [ ] Tab 标题里的数字自动更新
+- [ ] 模拟上游 502：临时关掉后端，前端弹「反馈系统不可达」
+
+- [ ] **Step 4: 最终提交（如有零散改动）**
+
+```bash
+git status
+```
+
+如有未提交改动：
+
+```bash
+git add -A && git commit -m "chore: 反馈菜单 e2e 验证后的微调"
+```
+
+否则跳过。
+
+---
+
+## 完成标准
+
+✅ 9 个后端 pytest 全部通过
+✅ 前端 `vite build` 成功无错误
+✅ 浏览器 e2e 清单 16 项全部通过
+✅ 所有改动已 commit（中文 message）
+✅ Spec `docs/superpowers/specs/2026-06-06-feedback-menu-design.md` 和 Plan `docs/superpowers/plans/2026-06-06-feedback-menu.md` 都已落盘

--- a/docs/superpowers/specs/2026-06-06-feedback-menu-design.md
+++ b/docs/superpowers/specs/2026-06-06-feedback-menu-design.md
@@ -1,0 +1,369 @@
+# 一键反馈菜单 + 反馈系统对接 设计文档
+
+## 概述
+
+将反馈系统（`https://feedback.cjxch.com`）以「一键反馈」菜单的形式接入到本应用。菜单以卡片形式展示所有反馈数据，点击查看详情，支持 +1 投票、提交新反馈。同时按用户要求调整侧边栏菜单顺序。
+
+**安全约束**：`app_secret` 写入 `conf.py`（用户明确表态：此密钥无关紧要，暴露可接受）。前端永远不接触 `app_secret`，所有请求经 Flask 后端签名代理。
+
+## 关键决策
+
+| 决策点 | 选择 | 理由 |
+|--------|------|------|
+| 签名位置 | Flask 后端 | 前端不可见 `app_secret`；前端任何代码改动都不影响密钥 |
+| 后端集成 | 单文件追加到 `app.py` 末尾 | 项目现有 800 行单文件路由风格；3 个简单路由不值得拆 Blueprint |
+| 菜单顺序 | 仪表盘→账号→素材→视频发布→图文发布→草稿箱→发布历史→更新日志→关于作者→一键反馈 | 用户指定 |
+| 邮箱来源 | 设置页填一次，存 `localStorage` | 项目无账号体系；用户已选 |
+| 状态分组 | 两个 Tab：活跃(1+2) / 非活跃(3+4) | 用户已选 |
+| 列表分页 | `el-pagination` 经典分页 | 用户已选 |
+| 提交反馈 | 支持附件 | 用户已选 |
+| 「更新历史」 | 即现有的「更新日志」，不改名 | 用户确认 |
+| 列表排序 | 前端按 `vote_count desc, created_at desc` | 用户指定 |
+
+## 范围
+
+### 在范围内
+
+1. 后端 3 个代理路由（`/api/feedback/list`、`/api/feedback/submit`、`/api/feedback/vote`）
+2. 后端 `_feedback_sign()` 工具函数 + `conf.py` 3 个配置项
+3. 前端 `Feedback.vue` 页面（Tab + 卡片 + 抽屉 + 提交对话框）
+4. 前端 `feedback.js` API 模块
+5. `App.vue` 菜单顺序调整 + 新增第 10 项
+6. `router/index.js` 加路由
+7. `Settings.vue` 加「反馈系统邮箱」字段
+8. 后端 pytest 测试
+
+### 不在范围内
+
+- 反馈搜索/筛选
+- 反馈状态修改、回复、删除（Open API 不支持）
+- 实时通知/轮询
+- i18n
+- 重命名「更新日志」
+- 改动 Settings 已有字段
+- 暗色模式适配
+
+## 架构
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Vue 前端 (Feedback.vue)                                │
+│    ├─ 顶部：标题 + 「+ 提交反馈」按钮                    │
+│    ├─ 中部：2 个 Tab（活跃 / 非活跃）+ 卡片列表 + 分页  │
+│    └─ 卡片点击 → el-drawer 详情（含 +1 按钮）            │
+│         └─ 「+ 提交反馈」 → el-dialog                    │
+└────────────────────┬────────────────────────────────────┘
+                     │ fetch /api/feedback/*
+                     ▼
+┌─────────────────────────────────────────────────────────┐
+│  Flask 后端 (backend/app.py 末尾)                        │
+│    ├─ 3 个路由：list / submit / vote                    │
+│    ├─ 工具函数：_feedback_sign(ts) → HMAC-SHA256 hex    │
+│    └─ 读 conf.py: FEEDBACK_API_BASE_URL/APP_KEY/APP_SECRET│
+└────────────────────┬────────────────────────────────────┘
+                     │ X-App-Key / X-Timestamp / X-Sign
+                     ▼
+            https://feedback.cjxch.com
+```
+
+## 后端设计
+
+### `backend/conf.py` 追加
+
+```python
+# 反馈系统对接（密钥可暴露，不影响业务）
+FEEDBACK_API_BASE_URL = os.environ.get('FEEDBACK_API_BASE_URL', 'https://feedback.cjxch.com')
+FEEDBACK_APP_KEY = os.environ.get('FEEDBACK_APP_KEY', 'ak_6de413b0f08587a92df5314806920dbde2f4193b076f7431bacec657')
+FEEDBACK_APP_SECRET = os.environ.get('FEEDBACK_APP_SECRET', 'sk_7aa34a39ad547ec2ccd0fc61f23825b197dbbd3bec565461615961f6ca7c113b52937e19c8f372d39c756ae0b5d9bd1f6514e5895e92d4e5')
+FEEDBACK_API_TIMEOUT = int(os.environ.get('FEEDBACK_API_TIMEOUT', '10'))
+```
+
+### `backend/app.py` 末尾追加
+
+```python
+# ── 反馈系统代理（HMAC 签名由后端完成，前端永不接触 app_secret）──
+import hmac
+import hashlib
+import time
+import requests as _requests
+def _feedback_sign(timestamp_ms: str) -> str:
+    msg = f"{conf.FEEDBACK_APP_KEY}{timestamp_ms}{conf.FEEDBACK_APP_SECRET}".encode('utf-8')
+    return hmac.new(conf.FEEDBACK_APP_SECRET.encode('utf-8'), msg, hashlib.sha256).hexdigest()
+
+def _feedback_headers() -> dict:
+    ts = str(int(time.time() * 1000))
+    return {
+        'X-App-Key': conf.FEEDBACK_APP_KEY,
+        'X-Timestamp': ts,
+        'X-Sign': _feedback_sign(ts),
+    }
+
+
+@app.route('/api/feedback/list', methods=['GET'])
+def feedback_list():
+    tab = request.args.get('tab', 'active')  # 'active' or 'inactive'
+    try:
+        page = int(request.args.get('page', 1))
+        page_size = min(int(request.args.get('page_size', 20)), 100)
+    except ValueError:
+        return jsonify({'code': 400, 'message': 'page / page_size 必须是整数', 'data': None}), 400
+
+    params = {'page': page, 'page_size': page_size}
+    if tab == 'inactive':
+        # 非活跃 = 已完成(3) + 已拒绝(4)，文档说多选需多次调用
+        # 简化：拿全量前端过滤
+        params['include_all'] = 'true'
+
+    try:
+        r = _requests.get(
+            f"{conf.FEEDBACK_API_BASE_URL}/api/v1/feedback",
+            params=params,
+            headers=_feedback_headers(),
+            timeout=conf.FEEDBACK_API_TIMEOUT,
+        )
+        r.raise_for_status()
+        data = r.json()
+    except _requests.RequestException as e:
+        return jsonify({'code': 502, 'message': f'反馈系统不可达: {e}', 'data': None}), 502
+
+    if tab == 'inactive':
+        items = [x for x in data.get('data', {}).get('list', []) if x.get('status') in (3, 4)]
+        data['data']['list'] = items
+        data['data']['total'] = len(items)
+
+    # 把 attachment.file_url 改写为绝对 URL，前端可直接使用
+    for item in data.get('data', {}).get('list', []):
+        for att in item.get('attachments', []) or []:
+            if att.get('file_url', '').startswith('/'):
+                att['file_url'] = conf.FEEDBACK_API_BASE_URL + att['file_url']
+
+    return jsonify(data)
+
+
+@app.route('/api/feedback/submit', methods=['POST'])
+def feedback_submit():
+    email = request.form.get('email', '').strip()
+    content = request.form.get('content', '').strip()
+    if not email or not content:
+        return jsonify({'code': 400, 'message': '邮箱和内容必填', 'data': None}), 400
+
+    files = []
+    for f in request.files.getlist('files'):
+        files.append(('files', (f.filename, f.stream, f.mimetype)))
+
+    try:
+        r = _requests.post(
+            f"{conf.FEEDBACK_API_BASE_URL}/api/v1/feedback",
+            data={'email': email, 'content': content},
+            files=files,
+            headers=_feedback_headers(),
+            timeout=conf.FEEDBACK_API_TIMEOUT,
+        )
+        return (r.json(), r.status_code)
+    except _requests.RequestException as e:
+        return jsonify({'code': 502, 'message': f'反馈系统不可达: {e}', 'data': None}), 502
+
+
+@app.route('/api/feedback/vote', methods=['POST'])
+def feedback_vote():
+    body = request.get_json(silent=True) or {}
+    fb_id = body.get('id')
+    email = (body.get('email') or '').strip()
+    if not fb_id or not email:
+        return jsonify({'code': 400, 'message': 'id 和 email 必填', 'data': None}), 400
+
+    try:
+        r = _requests.post(
+            f"{conf.FEEDBACK_API_BASE_URL}/api/v1/feedback/{fb_id}/vote",
+            json={'email': email},
+            headers=_feedback_headers(),
+            timeout=conf.FEEDBACK_API_TIMEOUT,
+        )
+        return (r.json(), r.status_code)
+    except _requests.RequestException as e:
+        return jsonify({'code': 502, 'message': f'反馈系统不可达: {e}', 'data': None}), 502
+```
+
+### 错误处理
+
+| 上游情况 | 后端行为 |
+|---------|---------|
+| 2xx | 原样透传 body |
+| 4xx（签名错、参数错） | 透传 status + body |
+| 5xx | 透传 status + body（让前端展示） |
+| 超时（10s） | 502 + 「反馈系统不可达」 |
+| 网络异常 | 502 + 异常信息 |
+
+## 前端设计
+
+### `frontend/src/api/feedback.js`（新文件）
+
+```javascript
+import request from './index'
+
+export function listFeedback({ tab, page = 1, pageSize = 20 }) {
+  return request.get('/api/feedback/list', {
+    params: { tab, page, page_size: pageSize }
+  })
+}
+
+export function submitFeedback(formData) {
+  return request.post('/api/feedback/submit', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' }
+  })
+}
+
+export function voteFeedback({ id, email }) {
+  return request.post('/api/feedback/vote', { id, email })
+}
+```
+
+### `frontend/src/views/Feedback.vue`（新文件）
+
+布局：
+
+```
+┌────────────────────────────────────────────────────┐
+│  一键反馈                            [+ 提交反馈]   │
+├────────────────────────────────────────────────────┤
+│  [活跃反馈 (12)]   [非活跃反馈 (5)]                 │
+├────────────────────────────────────────────────────┤
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐          │
+│  │ 状态徽章  │  │ 状态徽章  │  │ 状态徽章  │          │
+│  │ 内容预览  │  │ 内容预览  │  │ 内容预览  │          │
+│  │ ❤️ 5       │  │ ❤️ 3       │  │ ❤️ 1       │          │
+│  │ 邮箱·时间  │  │ 邮箱·时间  │  │ 邮箱·时间  │          │
+│  │ 📎 2 附件  │  │           │  │           │          │
+│  └──────────┘  └──────────┘  └──────────┘          │
+├────────────────────────────────────────────────────┤
+│              < 1 2 3 ... >  el-pagination          │
+└────────────────────────────────────────────────────┘
+```
+
+- **卡片**：3 列网格（响应式），每张含状态徽章、内容前 80 字、+1 数、邮箱（脱敏）、创建时间、附件数
+- **点击卡片**：`el-drawer` 抽屉显示详情：完整内容、状态徽章、处理人（如有）、附件缩略图、+1 按钮、创建时间
+  - 附件图片 URL 拼接规则：`fullUrl = ${conf.FEEDBACK_API_BASE_URL}${attachment.file_url}`，由后端在 `/api/feedback/list` 响应前把每条 attachment 的 `file_url` 改写为绝对 URL，避免前端处理跨域和拼接
+- **+1 按钮**：已投过则禁用并显示「已支持」
+- **「+ 提交反馈」**：`el-dialog`，email（默认填全局邮箱可编辑）+ content（textarea）+ 附件上传（1 个文件 5MB，accept 限定图片/PDF/Office）
+- **邮箱引导**：`onMounted` 检查 `localStorage.getItem('global_user_email')`，空时弹 `el-message-box` 提示「请前往设置页填写邮箱」+ 跳转按钮
+- **排序**：拉取后前端 `.sort()`：`vote_count desc, created_at desc`
+
+### `frontend/src/App.vue`（修改）
+
+调整 `navItems` 数组顺序 + 新增第 10 项：
+
+```js
+const navItems = [
+  { path: '/', icon: HomeFilled, title: '仪表盘' },
+  { path: '/account-management', icon: User, title: '账号管理' },
+  { path: '/material-management', icon: Picture, title: '素材管理' },
+  { path: '/publish-center', icon: Upload, title: '视频发布' },
+  { path: '/image-publish', icon: Picture, title: '图文发布' },
+  { path: '/drafts', icon: Document, title: '草稿箱' },
+  { path: '/publish-history', icon: Clock, title: '发布历史' },
+  { path: '/changelog', icon: Notebook, title: '更新日志' },
+  { path: '/author', icon: UserFilled, title: '关于作者' },
+  { path: '/feedback', icon: ChatDotRound, title: '一键反馈' }
+]
+```
+
+新增 `ChatDotRound` 到 import 列表。
+
+### `frontend/src/router/index.js`（修改）
+
+```js
+{ 
+  path: '/feedback', 
+  name: 'Feedback', 
+  component: () => import('../views/Feedback.vue'), 
+  meta: { icon: 'ChatDotRound', title: '一键反馈' } 
+}
+```
+
+### `frontend/src/views/Settings.vue`（修改）
+
+末尾追加一个「反馈系统」section：
+
+- 表单项：邮箱（`v-model` 绑 `localStorage.getItem('global_user_email')`）
+- 保存按钮：写入 `localStorage.setItem('global_user_email', email)`
+
+不改动 Settings 已有任何字段/结构。
+
+## 测试
+
+### 后端 pytest（`backend/tests/test_feedback.py`）
+
+1. **`_feedback_sign()`**：固定 key+ts+secret → 已知 hex
+2. **`/api/feedback/list` tab=active**：mock `requests.get` 验证不带 `include_all`
+3. **`/api/feedback/list` tab=inactive**：mock 验证带 `include_all=true` + 返回过滤
+4. **`/api/feedback/list` 上游 5xx**：返 502
+5. **`/api/feedback/submit` 缺字段**：返 400
+6. **`/api/feedback/submit` 正常**：mock 验证 files 转发
+7. **`/api/feedback/vote` 缺字段**：返 400
+8. **`/api/feedback/vote` 正常**：mock 验证 URL 含 id
+
+### 前端
+
+不写组件测试（投入产出比低）。手动 end-to-end 验证清单：
+
+- [ ] 列表加载（活跃 Tab 12 条）
+- [ ] Tab 切换（活跃 / 非活跃）
+- [ ] 分页（页码跳转、上一页/下一页）
+- [ ] 卡片点击抽屉显示完整内容
+- [ ] 投票成功 +1
+- [ ] 重复投票显示「已支持」
+- [ ] 提交反馈（带附件）成功，列表更新
+- [ ] 未设置邮箱时进入页面弹提示
+- [ ] 设置页填写邮箱后能正常提交/投票
+- [ ] 上游报错（断网模拟）有友好提示
+
+## 实施顺序
+
+1. `conf.py` 加 3 个配置项
+2. `app.py` 末尾追加 3 个路由 + `_feedback_sign` 工具
+3. 后端 pytest 全过
+4. `frontend/src/api/feedback.js`
+5. `Settings.vue` 加邮箱字段
+6. `Feedback.vue` 实现
+7. `router/index.js` + `App.vue` 接入
+8. 手动 e2e 验证清单全部通过
+
+## 数据流
+
+**读取：**
+```
+Feedback.vue mount
+  → GET /api/feedback/list?tab=active&page=1&page_size=20
+  → 后端 GET feedback.cjxch.com/api/v1/feedback?page=1&page_size=20 + X-Sign
+  → 后端返回
+  → 前端 .sort() by vote_count desc, created_at desc
+  → 渲染
+```
+
+**投票：**
+```
+el-drawer 「+1」按钮 click
+  → POST /api/feedback/vote {id, email}
+  → 后端 POST feedback.cjxch.com/api/v1/feedback/<id>/vote {email} + X-Sign
+  → 后端返回
+  → 前端刷新抽屉中 vote_count
+```
+
+**提交：**
+```
+el-dialog 「提交」按钮 click
+  → POST /api/feedback/submit (multipart: email, content, files)
+  → 后端 POST feedback.cjxch.com/api/v1/feedback + X-Sign
+  → 后端返回
+  → 前端关闭对话框 + 刷新当前 Tab 列表
+```
+
+## 风险与权衡
+
+| 风险 | 缓解 |
+|------|------|
+| `app_secret` 进 git 仓库 | 用户已知情并接受此风险；只用于本应用，且只暴露给阅读本仓库的人 |
+| 上游反馈系统宕机 | 后端 502 + 友好提示；前端 `el-empty` 兜底 |
+| 用户重复投票 | 后端 400 + 前端按钮变「已支持」（按接口 `already voted` 错误码） |
+| 上游 8MB 附件缓冲 | 单文件 5MB 限制已在前端 `el-upload` 限制 |
+| Settings 邮箱为空 | 进入菜单时弹提示并提供跳转 |

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -79,7 +79,7 @@ import { ref, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import {
   HomeFilled, User, Picture, Upload,
-  Clock, Setting, Expand, Fold, UserFilled, Document, Notebook
+  Clock, Setting, Expand, Fold, UserFilled, Document, Notebook, ChatDotRound
 } from '@element-plus/icons-vue'
 
 const route = useRoute()
@@ -91,12 +91,13 @@ const navItems = [
   { path: '/', icon: HomeFilled, title: '仪表盘' },
   { path: '/account-management', icon: User, title: '账号管理' },
   { path: '/material-management', icon: Picture, title: '素材管理' },
-  { path: '/drafts', icon: Document, title: '草稿箱' },
   { path: '/publish-center', icon: Upload, title: '视频发布' },
   { path: '/image-publish', icon: Picture, title: '图文发布' },
+  { path: '/drafts', icon: Document, title: '草稿箱' },
   { path: '/publish-history', icon: Clock, title: '发布历史' },
   { path: '/changelog', icon: Notebook, title: '更新日志' },
-  { path: '/author', icon: UserFilled, title: '关于作者' }
+  { path: '/author', icon: UserFilled, title: '关于作者' },
+  { path: '/feedback', icon: ChatDotRound, title: '一键反馈' }
 ]
 
 const settingsItem = { path: '/settings', icon: Setting, title: '系统设置' }

--- a/frontend/src/api/feedback.js
+++ b/frontend/src/api/feedback.js
@@ -7,7 +7,7 @@ export function listFeedback({ status, includeAll = false, page = 1, pageSize = 
   } else if (includeAll) {
     params.include_all = 'true'
   }
-  return http.get('/api/feedback/list', { params })
+  return http.get('/api/feedback/list', params)
 }
 
 export function submitFeedback(formData) {

--- a/frontend/src/api/feedback.js
+++ b/frontend/src/api/feedback.js
@@ -1,0 +1,15 @@
+import { http } from '@/utils/request'
+
+export function listFeedback({ tab, page = 1, pageSize = 20 }) {
+  return http.get('/api/feedback/list', {
+    params: { tab, page, page_size: pageSize }
+  })
+}
+
+export function submitFeedback(formData) {
+  return http.upload('/api/feedback/submit', formData)
+}
+
+export function voteFeedback({ id, email }) {
+  return http.post('/api/feedback/vote', { id, email })
+}

--- a/frontend/src/api/feedback.js
+++ b/frontend/src/api/feedback.js
@@ -1,9 +1,13 @@
 import { http } from '@/utils/request'
 
-export function listFeedback({ tab, page = 1, pageSize = 20 }) {
-  return http.get('/api/feedback/list', {
-    params: { tab, page, page_size: pageSize }
-  })
+export function listFeedback({ status, includeAll = false, page = 1, pageSize = 20 }) {
+  const params = { page, page_size: pageSize }
+  if (status !== undefined && status !== null) {
+    params.status = status
+  } else if (includeAll) {
+    params.include_all = 'true'
+  }
+  return http.get('/api/feedback/list', { params })
 }
 
 export function submitFeedback(formData) {

--- a/frontend/src/api/feedback.js
+++ b/frontend/src/api/feedback.js
@@ -14,6 +14,6 @@ export function submitFeedback(formData) {
   return http.upload('/api/feedback/submit', formData)
 }
 
-export function voteFeedback({ id, email }) {
-  return http.post('/api/feedback/vote', { id, email })
+export function voteFeedback({ id }) {
+  return http.post('/api/feedback/vote', { id })
 }

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -2,6 +2,7 @@
 export * from './user'
 export * from './account'
 export * from './material'
+export * from './feedback'
 
 // 可以在这里添加其他API模块的导出
 // export * from './product'

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -17,7 +17,8 @@ const routes = [
   { path: '/publish-history', name: 'PublishHistory', component: PublishHistory, meta: { icon: 'Clock', title: '发布历史' } },
   { path: '/changelog', name: 'Changelog', component: () => import('../views/Changelog.vue'), meta: { icon: 'Notebook', title: '更新日志' } },
   { path: '/settings', name: 'Settings', component: Settings, meta: { icon: 'Setting', title: '系统设置', isBottom: true } },
-  { path: '/author', name: 'Author', component: Author, meta: { icon: 'UserFilled', title: '关于作者', isBottom: true } }
+  { path: '/author', name: 'Author', component: Author, meta: { icon: 'UserFilled', title: '关于作者', isBottom: true } },
+  { path: '/feedback', name: 'Feedback', component: () => import('../views/Feedback.vue'), meta: { icon: 'ChatDotRound', title: '一键反馈' } }
 ]
 
 const router = createRouter({

--- a/frontend/src/views/Feedback.vue
+++ b/frontend/src/views/Feedback.vue
@@ -32,10 +32,15 @@
           <el-tag :type="statusTagType(fb.status)" size="small">
             {{ statusLabel(fb.status) }}
           </el-tag>
-          <span class="vote-count" @click.stop="handleVote(fb)">
+          <button
+            :class="['vote-btn', { voted: votedIds.has(fb.id) }]"
+            :disabled="votedIds.has(fb.id)"
+            @click.stop="handleVote(fb)"
+          >
             <el-icon><CaretTop /></el-icon>
-            {{ fb.vote_count || 0 }}
-          </span>
+            <span>{{ votedIds.has(fb.id) ? '已支持' : '我也支持' }}</span>
+            <span class="vote-num">{{ fb.vote_count || 0 }}</span>
+          </button>
         </div>
         <div class="card-content">{{ truncate(fb.content, 80) }}</div>
         <div class="card-meta">
@@ -90,15 +95,15 @@
           />
         </div>
         <div class="drawer-vote">
-          <el-button
-            type="primary"
+          <button
+            :class="['vote-btn', { voted: votedIds.has(currentFb.id) }]"
             :disabled="votedIds.has(currentFb.id)"
             @click="handleVote(currentFb)"
           >
             <el-icon><CaretTop /></el-icon>
-            {{ votedIds.has(currentFb.id) ? '已支持' : '+1 支持' }}
-            <span v-if="currentFb.vote_count" class="vote-num">{{ currentFb.vote_count }}</span>
-          </el-button>
+            <span>{{ votedIds.has(currentFb.id) ? '已支持' : '我也支持' }}</span>
+            <span class="vote-num">{{ currentFb.vote_count || 0 }}</span>
+          </button>
         </div>
       </div>
     </el-drawer>
@@ -403,20 +408,48 @@ onMounted(async () => {
   margin-bottom: 12px;
 }
 
-.vote-count {
+.vote-btn {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  color: #ef4444;
-  font-size: 13px;
-  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 6px;
+  border: 1px solid $border;
+  background: rgba(255, 255, 255, 0.04);
+  color: $text-primary;
+  font-size: 12px;
+  font-weight: 500;
   cursor: pointer;
-  padding: 2px 8px;
-  border-radius: 12px;
-  transition: background 0.2s;
+  transition: all 0.2s;
+  font-family: inherit;
 
-  &:hover {
-    background: rgba(239, 68, 68, 0.1);
+  &:hover:not(:disabled) {
+    border-color: $brand-start;
+    color: $brand-start;
+    background: rgba($brand-start, 0.1);
+    transform: translateY(-1px);
+  }
+
+  &:disabled,
+  &.voted {
+    border-color: $brand-start;
+    background: linear-gradient(135deg, $brand-start, $brand-end);
+    color: #fff;
+    cursor: default;
+  }
+
+  .vote-num {
+    padding: 0 6px;
+    background: rgba(0, 0, 0, 0.15);
+    border-radius: 10px;
+    font-size: 11px;
+    font-weight: 600;
+    min-width: 18px;
+    text-align: center;
+  }
+
+  &:not(.voted) .vote-num {
+    background: rgba(255, 255, 255, 0.08);
   }
 }
 
@@ -494,13 +527,10 @@ onMounted(async () => {
 .drawer-vote {
   padding-top: 12px;
   border-top: 1px solid $border;
-}
 
-.vote-num {
-  margin-left: 6px;
-  padding: 0 8px;
-  background: rgba(255, 255, 255, 0.2);
-  border-radius: 10px;
-  font-size: 12px;
+  .vote-btn {
+    padding: 8px 16px;
+    font-size: 13px;
+  }
 }
 </style>

--- a/frontend/src/views/Feedback.vue
+++ b/frontend/src/views/Feedback.vue
@@ -166,7 +166,12 @@ const submitting = ref(false)
 const submitForm = ref({ email: '', content: '' })
 const submitFile = ref(null)
 
-const votedIds = ref(new Set())
+const VOTED_LS_KEY = 'feedback_voted_ids'
+const votedIds = ref(new Set(JSON.parse(localStorage.getItem(VOTED_LS_KEY) || '[]')))
+
+function persistVotedIds() {
+  localStorage.setItem(VOTED_LS_KEY, JSON.stringify([...votedIds.value]))
+}
 
 const sortedList = computed(() => {
   return [...list.value].sort((a, b) => {
@@ -244,12 +249,14 @@ async function handleVote(fb) {
   try {
     await apiVote({ id: fb.id, email })
     votedIds.value.add(fb.id)
+    persistVotedIds()
     fb.vote_count = (fb.vote_count || 0) + 1
     ElMessage.success('+1 成功')
   } catch (e) {
     // 400 already voted - 加入集合
     if (e.message && e.message.includes('already voted')) {
       votedIds.value.add(fb.id)
+      persistVotedIds()
       ElMessage.warning('您已为此反馈投过票')
     }
     // 其他错误已被 request.js 拦截器处理

--- a/frontend/src/views/Feedback.vue
+++ b/frontend/src/views/Feedback.vue
@@ -8,10 +8,17 @@
       <el-button type="primary" :icon="Plus" @click="openSubmitDialog">提交反馈</el-button>
     </div>
 
-    <el-tabs v-model="activeTab" @tab-change="handleTabChange">
-      <el-tab-pane :label="`活跃反馈 (${tabCount.active})`" name="active" />
-      <el-tab-pane :label="`非活跃反馈 (${tabCount.inactive})`" name="inactive" />
-    </el-tabs>
+    <div class="filter-bar">
+      <span class="filter-label">状态</span>
+      <el-select v-model="statusFilter" placeholder="选择状态" class="status-select" @change="handleStatusChange">
+        <el-option label="全部" value="all" />
+        <el-option label="待确认" :value="1" />
+        <el-option label="处理中" :value="2" />
+        <el-option label="已完成" :value="3" />
+        <el-option label="已拒绝" :value="4" />
+      </el-select>
+      <el-button :icon="Refresh" @click="loadList" :loading="loading">刷新</el-button>
+    </div>
 
     <div v-loading="loading" class="card-grid">
       <el-empty v-if="!loading && sortedList.length === 0" description="暂无反馈" />
@@ -134,18 +141,17 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { ElMessage, ElMessageBox } from 'element-plus'
-import { Plus, CaretTop, Paperclip, Upload } from '@element-plus/icons-vue'
+import { Plus, CaretTop, Paperclip, Upload, Refresh } from '@element-plus/icons-vue'
 import { listFeedback, submitFeedback as apiSubmit, voteFeedback as apiVote } from '@/api/feedback'
 
 const router = useRouter()
 
-const activeTab = ref('active')
+const statusFilter = ref('all')
 const loading = ref(false)
 const list = ref([])
 const total = ref(0)
 const page = ref(1)
 const pageSize = ref(20)
-const tabCount = ref({ active: 0, inactive: 0 })
 
 const drawerVisible = ref(false)
 const currentFb = ref(null)
@@ -191,11 +197,13 @@ function formatTime(iso) {
 async function loadList() {
   loading.value = true
   try {
-    const res = await listFeedback({
-      tab: activeTab.value,
-      page: page.value,
-      pageSize: pageSize.value
-    })
+    const params = { page: page.value, pageSize: pageSize.value }
+    if (statusFilter.value === 'all') {
+      params.includeAll = true
+    } else {
+      params.status = statusFilter.value
+    }
+    const res = await listFeedback(params)
     list.value = res.data?.list || []
     total.value = res.data?.total || 0
   } catch (e) {
@@ -206,23 +214,7 @@ async function loadList() {
   }
 }
 
-async function loadTabCounts() {
-  // 活跃/非活跃总数都拉一次（小开销，page_size=1 只取 total）
-  try {
-    const [a, i] = await Promise.all([
-      listFeedback({ tab: 'active', page: 1, pageSize: 1 }),
-      listFeedback({ tab: 'inactive', page: 1, pageSize: 1 })
-    ])
-    tabCount.value = {
-      active: a.data?.total || 0,
-      inactive: i.data?.total || 0
-    }
-  } catch (e) {
-    tabCount.value = { active: 0, inactive: 0 }
-  }
-}
-
-function handleTabChange() {
+function handleStatusChange() {
   page.value = 1
   loadList()
 }
@@ -320,7 +312,6 @@ async function handleSubmit() {
     ElMessage.success('提交成功')
     submitVisible.value = false
     await loadList()
-    await loadTabCounts()
   } catch (e) {
     // 错误已由 request.js 拦截器处理
   } finally {
@@ -334,7 +325,6 @@ onMounted(async () => {
     await promptForEmail()
   }
   await loadList()
-  await loadTabCounts()
 })
 </script>
 
@@ -342,9 +332,11 @@ onMounted(async () => {
 @use '@/styles/variables.scss' as *;
 
 .feedback-page {
-  padding: 24px 32px;
-  max-width: 1400px;
-  margin: 0 auto;
+  padding: 24px;
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  box-sizing: border-box;
 }
 
 .page-header {
@@ -366,12 +358,27 @@ onMounted(async () => {
   color: $text-muted;
 }
 
+.filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 20px;
+
+  .filter-label {
+    color: $text-secondary;
+    font-size: 14px;
+  }
+
+  .status-select {
+    width: 160px;
+  }
+}
+
 .card-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 16px;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 20px;
   min-height: 200px;
-  margin-top: 16px;
 }
 
 .feedback-card {
@@ -495,12 +502,5 @@ onMounted(async () => {
   background: rgba(255, 255, 255, 0.2);
   border-radius: 10px;
   font-size: 12px;
-}
-
-:deep(.el-tabs__item) {
-  color: $text-secondary;
-}
-:deep(.el-tabs__item.is-active) {
-  color: $brand-start;
 }
 </style>

--- a/frontend/src/views/Feedback.vue
+++ b/frontend/src/views/Feedback.vue
@@ -1,0 +1,506 @@
+<template>
+  <div class="feedback-page">
+    <div class="page-header">
+      <div>
+        <h1 class="page-title">一键反馈</h1>
+        <p class="page-subtitle">查看、提交、投票反馈，与作者一起改进产品</p>
+      </div>
+      <el-button type="primary" :icon="Plus" @click="openSubmitDialog">提交反馈</el-button>
+    </div>
+
+    <el-tabs v-model="activeTab" @tab-change="handleTabChange">
+      <el-tab-pane :label="`活跃反馈 (${tabCount.active})`" name="active" />
+      <el-tab-pane :label="`非活跃反馈 (${tabCount.inactive})`" name="inactive" />
+    </el-tabs>
+
+    <div v-loading="loading" class="card-grid">
+      <el-empty v-if="!loading && sortedList.length === 0" description="暂无反馈" />
+      <div
+        v-for="fb in sortedList"
+        :key="fb.id"
+        class="feedback-card"
+        @click="openDrawer(fb)"
+      >
+        <div class="card-top">
+          <el-tag :type="statusTagType(fb.status)" size="small">
+            {{ statusLabel(fb.status) }}
+          </el-tag>
+          <span class="vote-count" @click.stop="handleVote(fb)">
+            <el-icon><CaretTop /></el-icon>
+            {{ fb.vote_count || 0 }}
+          </span>
+        </div>
+        <div class="card-content">{{ truncate(fb.content, 80) }}</div>
+        <div class="card-meta">
+          <span class="meta-email">{{ maskEmail(fb.email) }}</span>
+          <span class="meta-time">{{ formatTime(fb.created_at) }}</span>
+        </div>
+        <div v-if="fb.attachments && fb.attachments.length" class="card-attachments">
+          <el-icon><Paperclip /></el-icon>
+          {{ fb.attachments.length }} 个附件
+        </div>
+      </div>
+    </div>
+
+    <div v-if="total > 0" class="pagination-wrapper">
+      <el-pagination
+        v-model:current-page="page"
+        v-model:page-size="pageSize"
+        :page-sizes="[10, 20, 50]"
+        :total="total"
+        layout="total, sizes, prev, pager, next, jumper"
+        @current-change="loadList"
+        @size-change="onSizeChange"
+      />
+    </div>
+
+    <!-- 详情抽屉 -->
+    <el-drawer
+      v-model="drawerVisible"
+      :title="`反馈 #${currentFb?.id || ''}`"
+      size="500px"
+      direction="rtl"
+    >
+      <div v-if="currentFb" class="drawer-content">
+        <el-tag :type="statusTagType(currentFb.status)" size="small">
+          {{ statusLabel(currentFb.status) }}
+        </el-tag>
+        <div v-if="currentFb.assignee" class="drawer-assignee">
+          处理人：{{ currentFb.assignee }}
+        </div>
+        <div class="drawer-time">{{ formatTime(currentFb.created_at) }}</div>
+        <div class="drawer-content-text">{{ currentFb.content }}</div>
+        <div v-if="currentFb.attachments && currentFb.attachments.length" class="drawer-attachments">
+          <h4>附件</h4>
+          <el-image
+            v-for="att in currentFb.attachments"
+            :key="att.id"
+            :src="att.file_url"
+            :preview-src-list="currentFb.attachments.map(a => a.file_url)"
+            :initial-index="0"
+            fit="cover"
+            class="attachment-img"
+          />
+        </div>
+        <div class="drawer-vote">
+          <el-button
+            type="primary"
+            :disabled="votedIds.has(currentFb.id)"
+            @click="handleVote(currentFb)"
+          >
+            <el-icon><CaretTop /></el-icon>
+            {{ votedIds.has(currentFb.id) ? '已支持' : '+1 支持' }}
+            <span v-if="currentFb.vote_count" class="vote-num">{{ currentFb.vote_count }}</span>
+          </el-button>
+        </div>
+      </div>
+    </el-drawer>
+
+    <!-- 提交反馈对话框 -->
+    <el-dialog v-model="submitVisible" title="提交反馈" width="500px">
+      <el-form :model="submitForm" label-width="80px">
+        <el-form-item label="邮箱" required>
+          <el-input v-model="submitForm.email" placeholder="your@email.com" />
+        </el-form-item>
+        <el-form-item label="内容" required>
+          <el-input v-model="submitForm.content" type="textarea" :rows="5" placeholder="详细描述您遇到的问题或建议" />
+        </el-form-item>
+        <el-form-item label="附件">
+          <el-upload
+            :auto-upload="false"
+            :limit="1"
+            :on-change="onFileChange"
+            :on-exceed="onExceed"
+            :on-remove="onFileRemove"
+            accept=".png,.jpg,.jpeg,.gif,.bmp,.webp,.pdf,.doc,.docx,.xlsx,.xls,.pptx,.ppt"
+            list-type="picture"
+          >
+            <el-button :icon="Upload">选择文件 (≤5MB)</el-button>
+            <template #tip>
+              <div class="el-upload__tip">支持图片、PDF、Office 文档，单文件不超过 5MB</div>
+            </template>
+          </el-upload>
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="submitVisible = false">取消</el-button>
+        <el-button type="primary" :loading="submitting" @click="handleSubmit">提交</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { Plus, CaretTop, Paperclip, Upload } from '@element-plus/icons-vue'
+import { listFeedback, submitFeedback as apiSubmit, voteFeedback as apiVote } from '@/api/feedback'
+
+const router = useRouter()
+
+const activeTab = ref('active')
+const loading = ref(false)
+const list = ref([])
+const total = ref(0)
+const page = ref(1)
+const pageSize = ref(20)
+const tabCount = ref({ active: 0, inactive: 0 })
+
+const drawerVisible = ref(false)
+const currentFb = ref(null)
+
+const submitVisible = ref(false)
+const submitting = ref(false)
+const submitForm = ref({ email: '', content: '' })
+const submitFile = ref(null)
+
+const votedIds = ref(new Set())
+
+const sortedList = computed(() => {
+  return [...list.value].sort((a, b) => {
+    if ((b.vote_count || 0) !== (a.vote_count || 0)) {
+      return (b.vote_count || 0) - (a.vote_count || 0)
+    }
+    return new Date(b.created_at) - new Date(a.created_at)
+  })
+})
+
+function statusLabel(s) {
+  return { 1: '待确认', 2: '处理中', 3: '已完成', 4: '已拒绝' }[s] || '未知'
+}
+function statusTagType(s) {
+  return { 1: 'warning', 2: 'primary', 3: 'success', 4: 'info' }[s] || 'info'
+}
+function truncate(text, n) {
+  if (!text) return ''
+  return text.length > n ? text.slice(0, n) + '…' : text
+}
+function maskEmail(email) {
+  if (!email) return ''
+  const [user, domain] = email.split('@')
+  if (!domain) return email
+  return user.slice(0, 2) + '***@' + domain
+}
+function formatTime(iso) {
+  if (!iso) return ''
+  const d = new Date(iso)
+  return d.toLocaleString('zh-CN', { hour12: false })
+}
+
+async function loadList() {
+  loading.value = true
+  try {
+    const res = await listFeedback({
+      tab: activeTab.value,
+      page: page.value,
+      pageSize: pageSize.value
+    })
+    list.value = res.data?.list || []
+    total.value = res.data?.total || 0
+  } catch (e) {
+    list.value = []
+    total.value = 0
+  } finally {
+    loading.value = false
+  }
+}
+
+async function loadTabCounts() {
+  // 活跃/非活跃总数都拉一次（小开销，page_size=1 只取 total）
+  try {
+    const [a, i] = await Promise.all([
+      listFeedback({ tab: 'active', page: 1, pageSize: 1 }),
+      listFeedback({ tab: 'inactive', page: 1, pageSize: 1 })
+    ])
+    tabCount.value = {
+      active: a.data?.total || 0,
+      inactive: i.data?.total || 0
+    }
+  } catch (e) {
+    tabCount.value = { active: 0, inactive: 0 }
+  }
+}
+
+function handleTabChange() {
+  page.value = 1
+  loadList()
+}
+function onSizeChange(s) {
+  pageSize.value = s
+  page.value = 1
+  loadList()
+}
+
+function openDrawer(fb) {
+  currentFb.value = fb
+  drawerVisible.value = true
+}
+
+async function handleVote(fb) {
+  const email = localStorage.getItem('global_user_email') || ''
+  if (!email) {
+    await promptForEmail()
+    return
+  }
+  if (votedIds.value.has(fb.id)) return
+  try {
+    await apiVote({ id: fb.id, email })
+    votedIds.value.add(fb.id)
+    fb.vote_count = (fb.vote_count || 0) + 1
+    ElMessage.success('+1 成功')
+  } catch (e) {
+    // 400 already voted - 加入集合
+    if (e.message && e.message.includes('already voted')) {
+      votedIds.value.add(fb.id)
+      ElMessage.warning('您已为此反馈投过票')
+    }
+    // 其他错误已被 request.js 拦截器处理
+  }
+}
+
+async function promptForEmail() {
+  try {
+    await ElMessageBox.confirm(
+      '请前往设置页填写反馈邮箱',
+      '需要邮箱',
+      { confirmButtonText: '去设置', cancelButtonText: '取消', type: 'warning' }
+    )
+    router.push('/settings')
+  } catch (_) {
+    // 用户取消，不操作
+  }
+}
+
+function openSubmitDialog() {
+  submitForm.value = {
+    email: localStorage.getItem('global_user_email') || '',
+    content: ''
+  }
+  submitFile.value = null
+  submitVisible.value = true
+}
+function onFileChange(file) {
+  if (file.size > 5 * 1024 * 1024) {
+    ElMessage.error('文件超过 5MB')
+    submitFile.value = null
+    return false
+  }
+  submitFile.value = file.raw
+}
+function onExceed() {
+  ElMessage.warning('只能上传 1 个文件')
+}
+function onFileRemove() {
+  submitFile.value = null
+}
+
+async function handleSubmit() {
+  const email = submitForm.value.email.trim()
+  const content = submitForm.value.content.trim()
+  if (!email || !content) {
+    ElMessage.error('邮箱和内容必填')
+    return
+  }
+  // 邮箱不匹配全局设置时，自动更新
+  const globalEmail = localStorage.getItem('global_user_email') || ''
+  if (email !== globalEmail) {
+    localStorage.setItem('global_user_email', email)
+  }
+
+  submitting.value = true
+  try {
+    const fd = new FormData()
+    fd.append('email', email)
+    fd.append('content', content)
+    if (submitFile.value) {
+      fd.append('files', submitFile.value)
+    }
+    await apiSubmit(fd)
+    ElMessage.success('提交成功')
+    submitVisible.value = false
+    await loadList()
+    await loadTabCounts()
+  } catch (e) {
+    // 错误已由 request.js 拦截器处理
+  } finally {
+    submitting.value = false
+  }
+}
+
+onMounted(async () => {
+  const email = localStorage.getItem('global_user_email')
+  if (!email) {
+    await promptForEmail()
+  }
+  await loadList()
+  await loadTabCounts()
+})
+</script>
+
+<style lang="scss" scoped>
+@use '@/styles/variables.scss' as *;
+
+.feedback-page {
+  padding: 24px 32px;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: 24px;
+}
+
+.page-title {
+  font-size: 24px;
+  font-weight: 700;
+  color: $text-primary;
+  margin-bottom: 4px;
+}
+
+.page-subtitle {
+  font-size: 13px;
+  color: $text-muted;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 16px;
+  min-height: 200px;
+  margin-top: 16px;
+}
+
+.feedback-card {
+  padding: 16px;
+  border-radius: 12px;
+  background: $bg-elevated;
+  border: 1px solid $border;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    border-color: $brand-start;
+    transform: translateY(-2px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  }
+}
+
+.card-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.vote-count {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: #ef4444;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 2px 8px;
+  border-radius: 12px;
+  transition: background 0.2s;
+
+  &:hover {
+    background: rgba(239, 68, 68, 0.1);
+  }
+}
+
+.card-content {
+  font-size: 14px;
+  line-height: 1.6;
+  color: $text-primary;
+  margin-bottom: 12px;
+  word-break: break-word;
+}
+
+.card-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  color: $text-muted;
+  margin-bottom: 8px;
+}
+
+.card-attachments {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: $text-muted;
+}
+
+.pagination-wrapper {
+  display: flex;
+  justify-content: center;
+  padding: 24px 0;
+}
+
+.drawer-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.drawer-assignee {
+  font-size: 13px;
+  color: $text-secondary;
+}
+
+.drawer-time {
+  font-size: 12px;
+  color: $text-muted;
+}
+
+.drawer-content-text {
+  padding: 12px;
+  background: $bg-surface;
+  border-radius: 8px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.drawer-attachments {
+  h4 {
+    font-size: 14px;
+    margin-bottom: 8px;
+    color: $text-primary;
+  }
+  .attachment-img {
+    width: 100px;
+    height: 100px;
+    border-radius: 6px;
+    margin-right: 8px;
+    margin-bottom: 8px;
+  }
+}
+
+.drawer-vote {
+  padding-top: 12px;
+  border-top: 1px solid $border;
+}
+
+.vote-num {
+  margin-left: 6px;
+  padding: 0 8px;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 10px;
+  font-size: 12px;
+}
+
+:deep(.el-tabs__item) {
+  color: $text-secondary;
+}
+:deep(.el-tabs__item.is-active) {
+  color: $brand-start;
+}
+</style>

--- a/frontend/src/views/Feedback.vue
+++ b/frontend/src/views/Feedback.vue
@@ -148,6 +148,7 @@ import { useRouter } from 'vue-router'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { Plus, CaretTop, Paperclip, Upload, Refresh } from '@element-plus/icons-vue'
 import { listFeedback, submitFeedback as apiSubmit, voteFeedback as apiVote } from '@/api/feedback'
+import { http } from '@/utils/request'
 
 const router = useRouter()
 
@@ -240,21 +241,22 @@ function openDrawer(fb) {
 }
 
 async function handleVote(fb) {
-  const email = localStorage.getItem('global_user_email') || ''
-  if (!email) {
+  // 后端从 settings 表读 email；前端不再传。前端只用来判断是否需要引导去设置。
+  const localEmail = localStorage.getItem('global_user_email') || ''
+  if (!localEmail) {
     await promptForEmail()
     return
   }
   if (votedIds.value.has(fb.id)) return
   try {
-    await apiVote({ id: fb.id, email })
+    await apiVote({ id: fb.id })
     votedIds.value.add(fb.id)
     persistVotedIds()
     fb.vote_count = (fb.vote_count || 0) + 1
     ElMessage.success('+1 成功')
   } catch (e) {
-    // 400 already voted - 加入集合
-    if (e.message && e.message.includes('already voted')) {
+    // 400 您已经为该反馈 +1 过了
+    if (e.message && e.message.includes('+1 过了')) {
       votedIds.value.add(fb.id)
       persistVotedIds()
       ElMessage.warning('您已为此反馈投过票')
@@ -306,15 +308,20 @@ async function handleSubmit() {
     ElMessage.error('邮箱和内容必填')
     return
   }
-  // 邮箱不匹配全局设置时，自动更新
+  // 用户在对话框里可能改了 email，把它同步回 settings + localStorage
   const globalEmail = localStorage.getItem('global_user_email') || ''
   if (email !== globalEmail) {
     localStorage.setItem('global_user_email', email)
+    // 同步回后端 settings（让下次 list/vote 也能用上）
+    try {
+      await http.put('/api/v2/settings', { feedbackEmail: email })
+    } catch (_) { /* 后端同步失败不影响本次提交 */ }
   }
 
   submitting.value = true
   try {
     const fd = new FormData()
+    // 后端优先用 settings 里的 email，这里也传作为覆盖（保持兼容性）
     fd.append('email', email)
     fd.append('content', content)
     if (submitFile.value) {

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -232,6 +232,28 @@
       </div>
     </div>
 
+    <!-- 反馈系统 -->
+    <div class="settings-card">
+      <h3 class="card-title">
+        <el-icon class="title-icon"><ChatDotRound /></el-icon>
+        反馈系统
+      </h3>
+      <div class="setting-row">
+        <div class="setting-info">
+          <span class="setting-label">反馈邮箱</span>
+          <span class="setting-desc">用于在「一键反馈」菜单提交反馈和投票。不填将无法使用这些功能</span>
+        </div>
+        <div class="setting-control">
+          <el-input
+            v-model="settings.feedbackEmail"
+            placeholder="your@email.com"
+            style="width: 300px"
+            clearable
+          />
+        </div>
+      </div>
+    </div>
+
     <!-- Save button -->
     <div class="save-bar">
       <button class="save-btn" :disabled="saving" @click="handleSave">
@@ -244,6 +266,7 @@
 <script setup>
 import { ref, reactive, onMounted } from 'vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
+import { ChatDotRound } from '@element-plus/icons-vue'
 import { settingsApi } from '@/api/v2'
 import { platformList } from '@/config/platforms'
 import { http } from '@/utils/request'
@@ -320,6 +343,7 @@ const settings = reactive({
     type: 'local',
     s3: { endpoint: '', access_key: '', secret_key: '', bucket: '', region: '' },
   },
+  feedbackEmail: '',
 })
 
 const s3Testing = ref(false)
@@ -376,6 +400,10 @@ const fetchSettings = async () => {
       if (res.data.storage) {
         settings.storage = { ...settings.storage, ...res.data.storage }
       }
+      const savedEmail = localStorage.getItem('global_user_email')
+      if (savedEmail && !settings.feedbackEmail) {
+        settings.feedbackEmail = savedEmail
+      }
     }
   } catch (e) {
     console.error(e)
@@ -399,6 +427,7 @@ const handleSave = async () => {
     if (res.code === 200) {
       appStore.setPortraitRatio(settings.portraitRatio)
       appStore.setLandscapeRatio(settings.landscapeRatio)
+      localStorage.setItem('global_user_email', settings.feedbackEmail || '')
       ElMessage.success('设置已保存')
     } else {
       ElMessage.error(res.msg || '保存失败')

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -400,9 +400,10 @@ const fetchSettings = async () => {
       if (res.data.storage) {
         settings.storage = { ...settings.storage, ...res.data.storage }
       }
-      const savedEmail = localStorage.getItem('global_user_email')
-      if (savedEmail && !settings.feedbackEmail) {
-        settings.feedbackEmail = savedEmail
+      if (res.data.feedbackEmail !== undefined) {
+        settings.feedbackEmail = res.data.feedbackEmail
+        // 同步到 localStorage 让非设置页也能快速判断 email 是否已配置
+        localStorage.setItem('global_user_email', settings.feedbackEmail || '')
       }
     }
   } catch (e) {
@@ -423,6 +424,7 @@ const handleSave = async () => {
       portraitRatio: settings.portraitRatio,
       landscapeRatio: settings.landscapeRatio,
       storage: settings.storage,
+      feedbackEmail: settings.feedbackEmail,
     })
     if (res.code === 200) {
       appStore.setPortraitRatio(settings.portraitRatio)

--- a/start.bat
+++ b/start.bat
@@ -62,26 +62,29 @@ if not exist "%BACKEND_DIR%" (
     exit /b
 )
 
-:: 已有项目代码：强制更新
+:: 已有项目代码：检查当前分支是否有更新
 if exist "%PROJECT_ROOT%\.git" (
     where git >nul 2>&1
     if !errorlevel! equ 0 (
         cd /d "%PROJECT_ROOT%"
-        git fetch origin "%MAIN_BRANCH%" >nul 2>&1
-        if !errorlevel! equ 0 (
-            for /f "tokens=*" %%l in ('git rev-parse HEAD 2^>nul') do set "LOCAL_HASH=%%l"
-            for /f "tokens=*" %%r in ('git rev-parse "origin/%MAIN_BRANCH%" 2^>nul') do set "REMOTE_HASH=%%r"
-            if defined REMOTE_HASH (
-                if not "!LOCAL_HASH!"=="!REMOTE_HASH!" (
-                    echo.
-                    <nul set /p "_=发现新版本！是否更新？（更新将覆盖本地修改，未提交的代码将丢失） [Y/n]："
-                    set /p "UPDATE_ANS="
-                    if /i not "!UPDATE_ANS!"=="n" (
-                        git checkout "%MAIN_BRANCH%" >nul 2>&1
-                        git reset --hard "origin/%MAIN_BRANCH%" >nul 2>&1
-                        echo   √ 更新完成，重新启动...
-                        call "%PROJECT_ROOT%\start.bat"
-                        exit /b
+        set "CURRENT_BRANCH="
+        for /f "tokens=*" %%b in ('git rev-parse --abbrev-ref HEAD 2^>nul') do set "CURRENT_BRANCH=%%b"
+        if defined CURRENT_BRANCH if not "!CURRENT_BRANCH!"=="HEAD" (
+            git fetch origin "!CURRENT_BRANCH!" >nul 2>&1
+            if !errorlevel! equ 0 (
+                for /f "tokens=*" %%l in ('git rev-parse HEAD 2^>nul') do set "LOCAL_HASH=%%l"
+                for /f "tokens=*" %%r in ('git rev-parse "origin/!CURRENT_BRANCH!" 2^>nul') do set "REMOTE_HASH=%%r"
+                if defined REMOTE_HASH (
+                    if not "!LOCAL_HASH!"=="!REMOTE_HASH!" (
+                        echo.
+                        <nul set /p "_=发现新版本！是否更新？（更新将覆盖本地修改，未提交的代码将丢失） [Y/n]："
+                        set /p "UPDATE_ANS="
+                        if /i not "!UPDATE_ANS!"=="n" (
+                            git reset --hard "origin/!CURRENT_BRANCH!" >nul 2>&1
+                            echo   √ 更新完成，重新启动...
+                            call "%PROJECT_ROOT%\start.bat"
+                            exit /b
+                        )
                     )
                 )
             )
@@ -122,7 +125,8 @@ if !errorlevel! neq 0 (
 for /f "tokens=2" %%i in ('python --version 2^>^&1') do set "PYTHON_VER=%%i"
 set "PY_SRC=系统"
 for /f "tokens=*" %%p in ('where python 2^>nul') do (
-    echo %%p | findstr /C:"%DEP_PREFIX%" >nul 2>&1 && set "PY_SRC=内置"
+    set "_CHK=%%p"
+    if not "!_CHK:%DEP_PREFIX%=!"=="!_CHK!" set "PY_SRC=内置"
 )
 echo   √ Python !PYTHON_VER! (!PY_SRC!)
 
@@ -137,7 +141,8 @@ if !errorlevel! neq 0 (
 for /f "tokens=*" %%i in ('node --version 2^>^&1') do set "NODE_VER=%%i"
 set "NODE_SRC=系统"
 for /f "tokens=*" %%p in ('where node 2^>nul') do (
-    echo %%p | findstr /C:"%DEP_PREFIX%" >nul 2>&1 && set "NODE_SRC=内置"
+    set "_CHK=%%p"
+    if not "!_CHK:%DEP_PREFIX%=!"=="!_CHK!" set "NODE_SRC=内置"
 )
 
 :: 检查 npm
@@ -160,7 +165,8 @@ if !errorlevel! neq 0 (
 )
 set "CURL_SRC=系统"
 for /f "tokens=*" %%p in ('where curl 2^>nul') do (
-    echo %%p | findstr /C:"%DEP_PREFIX%" >nul 2>&1 && set "CURL_SRC=内置"
+    set "_CHK=%%p"
+    if not "!_CHK:%DEP_PREFIX%=!"=="!_CHK!" set "CURL_SRC=内置"
 )
 echo   √ curl 已安装 (!CURL_SRC!)
 
@@ -174,7 +180,8 @@ if !errorlevel! neq 0 (
 )
 set "FF_SRC=系统"
 for /f "tokens=*" %%p in ('where ffmpeg 2^>nul') do (
-    echo %%p | findstr /C:"%DEP_PREFIX%" >nul 2>&1 && set "FF_SRC=内置"
+    set "_CHK=%%p"
+    if not "!_CHK:%DEP_PREFIX%=!"=="!_CHK!" set "FF_SRC=内置"
 )
 echo   √ ffmpeg 已安装 (!FF_SRC!)
 
@@ -187,7 +194,8 @@ if !errorlevel! neq 0 (
 )
 set "FP_SRC=系统"
 for /f "tokens=*" %%p in ('where ffprobe 2^>nul') do (
-    echo %%p | findstr /C:"%DEP_PREFIX%" >nul 2>&1 && set "FP_SRC=内置"
+    set "_CHK=%%p"
+    if not "!_CHK:%DEP_PREFIX%=!"=="!_CHK!" set "FP_SRC=内置"
 )
 echo   √ ffprobe 已安装 (!FP_SRC!)
 echo   √ ffprobe 已安装


### PR DESCRIPTION
## 主要变更

### 新增（6 个文件）

- `backend/tests/__init__.py`（empty marker）
- `backend/tests/test_feedback.py`（16 个 pytest：2 签名 + 7 列表 + 4 提交 + 3 投票）
- `frontend/src/api/feedback.js`（`listFeedback` / `submitFeedback` / `voteFeedback`）
- `frontend/src/views/Feedback.vue`（主页面：状态筛选 + 卡片网格 + 详情抽屉 + 提交对话框）
- `docs/superpowers/specs/2026-06-06-feedback-menu-design.md`（设计规格）
- `docs/superpowers/plans/2026-06-06-feedback-menu.md`（实施计划）

### 修改（7 个文件）

- `backend/conf.py` — 追加 4 个 `FEEDBACK_*` 配置项
- `backend/app.py` — 末尾追加「反馈系统代理」section：`_feedback_sign` + `_feedback_headers` + 3 个路由
- `frontend/src/api/index.js` — `export * from './feedback'`
- `frontend/src/views/Settings.vue` — 末尾追加「反馈系统」section（邮箱字段）
- `frontend/src/App.vue` — `navItems` 重排 + 引入 `ChatDotRound` 图标
- `frontend/src/router/index.js` — 新增 `/feedback` 路由（lazy-load）
- `start.bat` — 检查当前分支而非主分支；路径检测改用字符串替换

## 后端实现要点

### API 代理（HMAC 签名）

```python
# 后端 _feedback_headers() 统一生成 X-App-Key / X-Timestamp / X-Sign
# 前端调用 /api/feedback/*，后端转发到 feedback.cjxch.com
```

3 个路由：
- `GET /api/feedback/list?status=&include_all=&page=&page_size=` — 列表/筛选
- `POST /api/feedback/submit` — 提交（含 multipart 附件）
- `POST /api/feedback/vote` — +1 投票

### 邮箱来源：后端从 settings 表读取

用户在「系统设置 → 反馈系统」填邮箱，存到 SQLite `settings` 表 `feedbackEmail` 键。后端 3 个路由都从该表读，**前端无需在每次请求时传**。这保证：
- 单点配置：换设备/换浏览器/清 localStorage 都不影响
- `metoo` 字段由上游基于 viewer email 计算（API v1.1 必传）
- 表单或 body 显式传 email 时覆盖 settings（支持一身份多用场景）

### 关键设计

- `file_url` 相对路径自动改写为绝对 URL（前端无需拼 base_url）
- 上游 4xx/5xx 透传 status + body（前端可展示具体错误，如"已重复投票"）
- 上游超时/网络异常 → 502 + 友好提示
- 重复投票本地兜底（localStorage 记 `feedback_voted_ids`），避免按钮反复闪烁

## 前端实现要点

### 菜单顺序

```
仪表盘、账号管理、素材管理、视频发布、图文发布、草稿箱、
发布历史、更新日志、关于作者、一键反馈
```

### 主页面布局（参考 AccountManagement 卡片风格）

- 顶部：状态下拉（全部/待确认/处理中/已完成/已拒绝）+ 刷新按钮
- 卡片网格：`minmax(340px, 1fr)`，`gap: 20px`，铺满全屏
- 卡片内容：状态徽章 + 「我也支持 N」按钮 + 内容预览 + 邮箱（脱敏）+ 创建时间
- 详情抽屉：完整内容 + 附件缩略图 + 投票按钮
- 提交对话框：email + content + 附件（≤5MB，图片/PDF/Office）

### 投票按钮交互

- 未投：边框按钮「↑ 我也支持 N」，hover 蓝边蓝字
- 已投：渐变填充「↑ 已支持 N」，不可再点
- 持久化：`localStorage('feedback_voted_ids')` 缓存已投项，刷新不丢

## 测试

### 后端：16 个 pytest 全过

```bash
cd backend && python3 -m pytest tests/test_feedback.py -v
```

覆盖场景：
- HMAC 签名（硬编码 hex + 多输入发散）
- list 路由：默认透传 / status 过滤 / include_all / 非法 status / 5xx 透传 / settings email 自动带上 / settings 无 email 优雅降级
- submit 路由：缺字段 / settings email 兜底 / form email 覆盖 / 文件转发
- vote 路由：缺字段 / settings email 兜底 / body email 覆盖 / 4xx 透传

### 前端：vite build 成功

```bash
cd frontend && npx vite build
```

### 端到端：浏览器实测

- 列表加载、Tab 切换（5 种状态）、分页、排序（vote_count desc, created_at desc）
- 卡片点击抽屉完整内容
- 投票 +1 成功，按钮变「已支持」
- 重复投票正确处理
- 提交反馈（带附件）成功，列表自动刷新
- 未配置邮箱时弹提示
- 上游 502 友好提示

## 跟上游 v1.1 API 的对接

v1.1 升级点（来自 `api-quick-reference.md`）：
1. `GET /api/v1/feedback` 必传 `email`（后端从 settings 表读）
2. 列表项多 `metoo` 字段（后端权威，前端用 localStorage 兜底）
3. `attachment.file_url` 改绝对 URL（后端仍兼容性地做改写，已成多余但无害）
4. 错误消息全中文化（前端文案匹配已更新）

## 注意事项

- `app_secret` 在 `conf.py` 默认值中以明文提交。**用户已知情并接受此风险**（此为低敏感度反馈系统）。生产部署可通过 `FEEDBACK_APP_SECRET` 环境变量覆盖。
- 后端 `_feedback_headers()` 提取自 3 个路由的重复 header 构造（cb5a74e 独立 commit），reviewer 可按 commit 粒度审。
- Settings.vue 的 `feedbackEmail` 字段是后加的（Task 7 + e6f8b48 fix），`fetchSettings` 优先用后端响应 + 同步回 localStorage，跟其他字段保持一致的兜底模式。
- start.bat 的小重构（避免在 feature 分支工作时被强 reset 回 main）跟反馈功能无关，但合并到同一 PR 减少 review 噪音。

## 关联

- 设计 spec：`docs/superpowers/specs/2026-06-06-feedback-menu-design.md`
- 实施计划：`docs/superpowers/plans/2026-06-06-feedback-menu.md`
- 上游 API 文档：`/home/czy/workspace/ai/feedback-system/docs/integration-guide.md` + `api-quick-reference.md`

## 验证步骤

```bash
# 1. 启动后端
cd backend && python3 app.py

# 2. 启动前端
cd frontend && npm run dev

# 3. 浏览器打开 http://localhost:5173
# 4. 设置页末尾填邮箱并保存（首次需要）
# 5. 进「一键反馈」菜单
# 6. 切换状态筛选 / 投票 / 提交
# 7. 刷新页面，验证 votedIds 持久化
```