### PR TITLE
修复启动脚本递归调用错误

### DIFF
--- a/start-beta.bat
+++ b/start-beta.bat
@@ -58,7 +58,7 @@ if not exist "%BACKEND_DIR%" (
     git checkout -f "%MAIN_BRANCH%"
     echo   √ 项目代码拉取完成
     echo.
-    call "%PROJECT_ROOT%\start.bat"
+    call "%PROJECT_ROOT%\start-beta.bat"
     exit /b
 )
 

--- a/start-beta.sh
+++ b/start-beta.sh
@@ -60,7 +60,7 @@ if [[ ! -d "$BACKEND_DIR" ]]; then
     git checkout -f "$MAIN_BRANCH"
     echo -e "${CHECK} 项目代码拉取完成"
     echo ""
-    exec bash "$PROJECT_ROOT/start.sh"
+    exec bash "$PROJECT_ROOT/start-beta.sh"
 fi
 
 # 已有项目代码：强制更新
@@ -77,7 +77,7 @@ if command -v git &>/dev/null && [[ -d "$PROJECT_ROOT/.git" ]]; then
             if [[ ! "$answer" =~ ^[Nn]$ ]]; then
                 git reset --hard "origin/$MAIN_BRANCH"
                 echo -e "${CHECK} 更新完成，重新启动..."
-                exec bash "$PROJECT_ROOT/start.sh"
+                exec bash "$PROJECT_ROOT/start-beta.sh"
             fi
         fi
     fi

--- a/start.bat
+++ b/start.bat
@@ -62,7 +62,7 @@ if not exist "%BACKEND_DIR%" (
     exit /b
 )
 
-:: 已有项目代码：检查 beta 分支是否有更新
+:: 已有项目代码：检查 master 分支是否有更新
 if exist "%PROJECT_ROOT%\.git" (
     where git >nul 2>&1
     if !errorlevel! equ 0 (
@@ -80,7 +80,7 @@ if exist "%PROJECT_ROOT%\.git" (
                     if /i not "!UPDATE_ANS!"=="n" (
                         git reset --hard "origin/%MAIN_BRANCH%" >nul 2>&1
                         echo   √ 更新完成，重新启动...
-                        call "%PROJECT_ROOT%\start-beta.bat"
+                        call "%PROJECT_ROOT%\start.bat"
                         exit /b
                     )
                 )


### PR DESCRIPTION
start-beta 启动脚本首次克隆后错误调用 start/start.sh，改为调用自身 start-beta/start-beta.sh。 start.bat 更新后重启错误调用 start-beta.bat，改为调用自身 start.bat。 修正 start.bat 注释：检查的是 master 分支而非 beta 分支。