### PR TITLE
fix(login): 释放终态扫码登录 SSE 连接

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -74,11 +74,23 @@ app.config['MAX_CONTENT_LENGTH'] = 1024 * 1024 * 1024
 active_queues: dict[str, Queue] = {}
 
 
+def _is_terminal_login_sse_message(message: str) -> bool:
+    if message in {"200", "500"}:
+        return True
+    try:
+        payload = json.loads(message)
+    except (TypeError, json.JSONDecodeError):
+        return False
+    return str(payload.get("status", "")).lower() in {"200", "500", "0", "error"}
+
+
 def sse_stream(status_queue):
     while True:
         if not status_queue.empty():
             msg = status_queue.get()
             yield f"data: {msg}\n\n"
+            if _is_terminal_login_sse_message(msg):
+                break
         else:
             time.sleep(0.1)
 

--- a/backend/tests/test_login_sse_stream.py
+++ b/backend/tests/test_login_sse_stream.py
@@ -1,0 +1,30 @@
+import json
+import sys
+import unittest
+from pathlib import Path
+from queue import Queue
+from unittest.mock import patch
+
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BACKEND_DIR))
+
+
+class TestLoginSseStream(unittest.TestCase):
+    def test_terminal_error_message_closes_stream(self):
+        import app as app_module
+
+        status_queue = Queue()
+        payload = json.dumps({"status": "error", "msg": "user closed browser"})
+        status_queue.put(payload)
+
+        stream = app_module.sse_stream(status_queue)
+
+        self.assertEqual(next(stream), f"data: {payload}\n\n")
+        with patch.object(app_module.time, "sleep", side_effect=AssertionError("stream kept waiting")):
+            with self.assertRaises(StopIteration):
+                next(stream)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_tasks_endpoint.py
+++ b/backend/tests/test_tasks_endpoint.py
@@ -15,8 +15,11 @@ DB_PATH = Path(_tmpdir) / "db" / "database.db"
 
 def _setup():
     DB_PATH.parent.mkdir(parents=True, exist_ok=True)
-    from init_db import init_database
+    import init_db as init_db_module
+    init_db_module.DB_PATH = DB_PATH
+    from init_db import init_database, migrate_database
     init_database()
+    migrate_database()
     conn = sqlite3.connect(str(DB_PATH))
     conn.execute("INSERT INTO publish_batches (id, type, title, status, account_count, created_at) VALUES ('tb1', 'video', 'batch', 'running', 2, '2026-06-01')")
     conn.execute("INSERT INTO publish_details (id, batch_id, account_name, platform, account_configs, status) VALUES ('td1', 'tb1', '账号A', '抖音', '{}', 'running')")
@@ -31,6 +34,8 @@ class TestTasksEndpoint(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         _setup()
+        import ext_api
+        ext_api.DB_PATH = DB_PATH
         from ext_api import app
         cls.client = app.test_client()
 

--- a/frontend/src/views/AccountManagement.vue
+++ b/frontend/src/views/AccountManagement.vue
@@ -536,8 +536,8 @@ const connectSSE = (platform, accountId) => {
       const result = JSON.parse(data)
       if (result.status === '200') {
         loginStatus.value = '200'
+        closeSSEConnection()
         setTimeout(() => {
-          closeSSEConnection()
           setTimeout(() => {
             dialogVisible.value = false
             sseConnecting.value = false
@@ -557,6 +557,15 @@ const connectSSE = (platform, accountId) => {
         setTimeout(() => { loginStatus.value = '' }, 2000)
         return
       }
+      if (result.status === '0' || result.status === 'error') {
+        loginStatus.value = '500'
+        closeSSEConnection()
+        sseConnecting.value = false
+        qrCodeData.value = ''
+        ElMessage.error(result.msg || result.error || '登录已取消')
+        setTimeout(() => { loginStatus.value = '' }, 2000)
+        return
+      }
     } catch (e) {}
 
     if (data === '500') {
@@ -571,8 +580,8 @@ const connectSSE = (platform, accountId) => {
     } else if (data === '200') {
       // 兼容旧格式
       loginStatus.value = '200'
+      closeSSEConnection()
       setTimeout(() => {
-        closeSSEConnection()
         setTimeout(() => {
           dialogVisible.value = false
           sseConnecting.value = false


### PR DESCRIPTION
## Summary
- End login SSE streams after terminal success/failure/cancel messages so Waitress workers are released.
- Close the frontend EventSource immediately on terminal login events to avoid browser reconnects.
- Add regression coverage for login SSE termination and fix task endpoint test DB isolation.

## Test Plan
- backend/venv/bin/python -m unittest discover backend/tests -v
- cd frontend && npm run build
- git diff --cached --check

## Notes
- Real third-party QR scan login flow was not manually tested; it requires an actual scan session.