### PR TITLE
fix(backend): _resolve_cover_from_path 兼容 dict 输入,修复发布历史 500

### DIFF
--- a/backend/ext_api/__init__.py
+++ b/backend/ext_api/__init__.py
@@ -105,17 +105,29 @@ def _resolve_cover_url(material_id: str) -> str:
         return ''
 
 
-def _resolve_cover_from_path(stored_path: str) -> str:
-    """直接用 stored_path 构造 /api/materials/file/{path} URL。空串返回空。
+def _resolve_cover_from_path(stored_path) -> str:
+    """直接用 stored_path 构造 /api/materials/file/{path} URL。空串/无法解析返回空。
 
-    stored_path 可能是绝对路径（thumbnail_path 来自 _resolve_material_path，
-    例如 /home/czy/workspace/.../data/materials/2026/06/13/uuid.jpg），
-    也可能是相对路径（含 materials/ 前缀）。要构造 storage API 的 file 路由
-    URL，relative_path 必须等于 materials 表的 stored_path 列。
+    stored_path 可能是:
+    - 字符串:绝对路径(/home/.../data/materials/2026/06/13/uuid.jpg)
+      或相对路径(含 materials/ 前缀)
+    - dict:某些路径(草稿批量发布等)会把 task.cover_landscape(dict)
+      原样写进 account_configs,结构可能是 {stored_path|path|url: ...}
+    - None / 空:返回空串
+
+    任意输入都不应抛异常。
     """
-    if not stored_path:
+    if isinstance(stored_path, dict):
+        for key in ('stored_path', 'path', 'url', 'storedPath'):
+            v = stored_path.get(key)
+            if v:
+                stored_path = v
+                break
+        else:
+            return ''
+    if not stored_path or not isinstance(stored_path, str):
         return ''
-    # 绝对路径：剥掉 BASE_DIR（data 目录）的父前缀，保留 materials/ 之后的部分
+    # 绝对路径:剥掉 BASE_DIR(data 目录)的父前缀,保留 materials/ 之后的部分
     import re
     m = re.search(r'(?:^|/)data/(materials/.+)$', stored_path)
     if m:
@@ -123,7 +135,7 @@ def _resolve_cover_from_path(stored_path: str) -> str:
     elif stored_path.startswith('materials/'):
         relative = stored_path
     else:
-        # 兜底：取 basename
+        # 兜底:取 basename
         import os
         relative = os.path.basename(stored_path)
     return f"/api/materials/file/{urllib.parse.quote(relative, safe='')}"

--- a/backend/tests/test_history_endpoint.py
+++ b/backend/tests/test_history_endpoint.py
@@ -124,6 +124,46 @@ class TestHistoryEndpoint(unittest.TestCase):
         for field in ('id', 'account_name', 'platform', 'status'):
             self.assertIn(field, first_item)
 
+    def test_history_when_account_configs_cover_is_dict(self):
+        """account_configs.coverLandscape/coverPortrait 是 dict 时不应 500。
+
+        场景:草稿批量发布等路径把 task.cover_landscape(dict | None)原样
+        写进 account_configs。当 batch 没有物质 ID(封面来自抽帧)时,
+        _serialize_batch_with_items 会走 fallback_cover_url 分支,把 dict
+        传给 _resolve_cover_from_path,触发 re.search 报
+        "expected string or bytes-like object, got 'dict'"。
+        """
+        with sqlite3.connect(str(self.DB_PATH)) as conn:
+            conn.execute(
+                "INSERT INTO publish_batches (id, type, title, status, account_count, success_count, failed_count, created_at) "
+                "VALUES ('b3', 'video', 'cover-as-dict', 'success', 1, 1, 0, '2026-06-03 10:00:00')"
+            )
+            conn.execute(
+                "INSERT INTO publish_details (id, batch_id, account_name, platform, account_configs, status) "
+                "VALUES ('d6', 'b3', '账号F', '抖音', ?, 'success')",
+                (json.dumps({
+                    'title': 'cover-as-dict',
+                    'coverLandscape': {'stored_path': '/data/materials/2026/06/13/abc.jpg', 'url': ''},
+                    'coverPortrait': {'path': '/data/materials/2026/06/13/xyz.jpg'},
+                    'thumbnail_path': '/data/materials/2026/06/13/thumb.jpg',
+                }),)
+            )
+            conn.commit()
+
+        try:
+            resp = self.client.get('/api/v2/history?type=video')
+            self.assertEqual(resp.status_code, 200, resp.get_data(as_text=True))
+            data = resp.get_json()
+            self.assertEqual(data['code'], 200)
+            target = next((b for b in data['data']['items'] if b['id'] == 'b3'), None)
+            self.assertIsNotNone(target)
+            self.assertIn('cover_url', target)
+        finally:
+            with sqlite3.connect(str(self.DB_PATH)) as conn:
+                conn.execute("DELETE FROM publish_details WHERE id = 'd6'")
+                conn.execute("DELETE FROM publish_batches WHERE id = 'b3'")
+                conn.commit()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
用户反馈进入发布历史报错:expected string or bytes-like object, got 'dict'。

根因:task_queue._build_account_configs 把 task.cover_landscape / cover_portrait (dict | None)原样存进 account_configs.coverLandscape / coverPortrait。 当 batch 的 landscape/portrait_cover_material_id 都为空(封面来自抽帧) 时,_serialize_batch_with_items 走 fallback 分支,把 dict 传给 _resolve_cover_from_path,触发 re.search 报错。

修复:_resolve_cover_from_path 加 dict 兼容,从 stored_path / path / url / storedPath 任一字段提取字符串。空 dict / None / 非字符串都安全返回空串,
任意输入都不抛。

回归测试:test_history_when_account_configs_cover_is_dict 模拟真实场景 (coverLandscape/coverPortrait 都是 dict + thumbnail_path 是字符串), 断言 /api/v2/history?type=video 不再 500。