### PR TITLE
feat(backend): 发布历史默认过滤 v0.6.0 旧版本数据

### DIFF
--- a/backend/ext_api/__init__.py
+++ b/backend/ext_api/__init__.py
@@ -109,8 +109,10 @@ def _resolve_cover_from_path(stored_path) -> str:
     """直接用 stored_path 构造 /api/materials/file/{path} URL。空串/无法解析返回空。
 
     stored_path 可能是:
-    - 字符串:绝对路径(/home/.../data/materials/2026/06/13/uuid.jpg)
-      或相对路径(含 materials/ 前缀)
+    - Linux 绝对路径:/home/.../data/materials/2026/06/13/uuid.jpg
+    - Windows 绝对路径:D:\\...\\data\\materials\\2026\\06\\13\\uuid.jpg
+      (数据从 Windows 同步过来时常见)
+    - 相对路径(含 materials/ 前缀)
     - dict:某些路径(草稿批量发布等)会把 task.cover_landscape(dict)
       原样写进 account_configs,结构可能是 {stored_path|path|url: ...}
     - None / 空:返回空串
@@ -127,17 +129,14 @@ def _resolve_cover_from_path(stored_path) -> str:
             return ''
     if not stored_path or not isinstance(stored_path, str):
         return ''
-    # 绝对路径:剥掉 BASE_DIR(data 目录)的父前缀,保留 materials/ 之后的部分
-    import re
-    m = re.search(r'(?:^|/)data/(materials/.+)$', stored_path)
-    if m:
-        relative = m.group(1)
-    elif stored_path.startswith('materials/'):
-        relative = stored_path
+    # 跨平台:统一反斜杠为正斜杠,再找 materials/ 起始位置
+    normalized = stored_path.replace('\\', '/')
+    idx = normalized.find('materials/')
+    if idx >= 0:
+        relative = normalized[idx:]
     else:
         # 兜底:取 basename
-        import os
-        relative = os.path.basename(stored_path)
+        relative = normalized.rsplit('/', 1)[-1]
     return f"/api/materials/file/{urllib.parse.quote(relative, safe='')}"
 
 
@@ -384,7 +383,9 @@ def _serialize_batch_with_items(b, items):
 def get_history():
     """获取发布历史（按批次分组），支持分页、平台/状态/类型过滤
 
-    Query: type=video|image (可选), page=1, pageSize=20
+    Query: type=video|image (可选), page=1, pageSize=20, include_legacy=0|1
+    默认过滤掉 v0.6.0 旧版本数据(account_configs 不含 coverLandscape /
+    videoLandscape 任一字段且 source 为空),传 include_legacy=1 看全部。
     """
     type_ = request.args.get('type')
     status = request.args.get('status')
@@ -392,6 +393,7 @@ def get_history():
     time_range = request.args.get('timeRange')
     start_date = request.args.get('startDate')
     end_date = request.args.get('endDate')
+    include_legacy = request.args.get('include_legacy', '').lower() in ('1', 'true', 'yes')
     page = int(request.args.get('page', 1))
     page_size = int(request.args.get('pageSize', 20))
     offset = (page - 1) * page_size
@@ -419,6 +421,18 @@ def get_history():
     if end_date:
         conditions.append("created_at <= ?")
         params.append(end_date)
+    # 默认过滤旧版本数据(v0.6.0 时代)。判断标准:batch 至少有一个 detail
+    # 含 v0.7.0 新字段(coverLandscape / videoLandscape),或 batch.source 非空
+    if not include_legacy:
+        conditions.append("""EXISTS (
+            SELECT 1 FROM publish_details d
+            WHERE d.batch_id = publish_batches.id
+              AND (
+                json_extract(d.account_configs, '$.coverLandscape') IS NOT NULL
+                OR json_extract(d.account_configs, '$.videoLandscape') IS NOT NULL
+                OR publish_batches.source != ''
+              )
+        )""")
     where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
 
     try:

--- a/backend/tests/test_history_endpoint.py
+++ b/backend/tests/test_history_endpoint.py
@@ -25,11 +25,11 @@ def _setup_db(db_path: Path):
     conn.executescript(_SCHEMA_SQL)
     conn.execute("INSERT INTO publish_batches (id, type, title, status, account_count, success_count, failed_count, created_at) VALUES ('b1', 'video', '测试视频1', 'success', 3, 3, 0, '2026-06-01 10:00:00')")
     conn.execute("INSERT INTO publish_batches (id, type, title, status, account_count, success_count, failed_count, created_at) VALUES ('b2', 'image', '测试图文1', 'partial', 2, 1, 1, '2026-06-02 10:00:00')")
-    conn.execute("INSERT INTO publish_details (id, batch_id, account_name, platform, account_configs, status) VALUES ('d1', 'b1', '账号A', '抖音', '{\"title\":\"测试视频1\"}', 'success')")
-    conn.execute("INSERT INTO publish_details (id, batch_id, account_name, platform, account_configs, status) VALUES ('d2', 'b1', '账号B', '小红书', '{\"title\":\"测试视频1\"}', 'success')")
-    conn.execute("INSERT INTO publish_details (id, batch_id, account_name, platform, account_configs, status) VALUES ('d3', 'b1', '账号C', 'B站', '{\"title\":\"测试视频1\"}', 'success')")
-    conn.execute("INSERT INTO publish_details (id, batch_id, account_name, platform, account_configs, status) VALUES ('d4', 'b2', '账号D', '抖音', '{}', 'success')")
-    conn.execute("INSERT INTO publish_details (id, batch_id, account_name, platform, account_configs, status) VALUES ('d5', 'b2', '账号E', '小红书', '{}', 'failed')")
+    conn.execute("INSERT INTO publish_details (id, batch_id, account_name, platform, account_configs, status) VALUES ('d1', 'b1', '账号A', '抖音', '{\"title\":\"测试视频1\",\"coverLandscape\":{\"stored_path\":\"/x.jpg\"}}', 'success')")
+    conn.execute("INSERT INTO publish_details (id, batch_id, account_name, platform, account_configs, status) VALUES ('d2', 'b1', '账号B', '小红书', '{\"title\":\"测试视频1\",\"coverLandscape\":{\"stored_path\":\"/x.jpg\"}}', 'success')")
+    conn.execute("INSERT INTO publish_details (id, batch_id, account_name, platform, account_configs, status) VALUES ('d3', 'b1', '账号C', 'B站', '{\"title\":\"测试视频1\",\"coverLandscape\":{\"stored_path\":\"/x.jpg\"}}', 'success')")
+    conn.execute("INSERT INTO publish_details (id, batch_id, account_name, platform, account_configs, status) VALUES ('d4', 'b2', '账号D', '抖音', '{\"coverLandscape\":{\"stored_path\":\"/x.jpg\"}}', 'success')")
+    conn.execute("INSERT INTO publish_details (id, batch_id, account_name, platform, account_configs, status) VALUES ('d5', 'b2', '账号E', '小红书', '{\"coverLandscape\":{\"stored_path\":\"/x.jpg\"}}', 'failed')")
     conn.commit()
     conn.close()
 
@@ -49,6 +49,8 @@ CREATE TABLE IF NOT EXISTS publish_batches (
     success_count INTEGER NOT NULL DEFAULT 0,
     failed_count INTEGER NOT NULL DEFAULT 0,
     schedule_time TEXT DEFAULT '',
+    source TEXT NOT NULL DEFAULT '',
+    draft_id INTEGER NOT NULL DEFAULT 0,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     started_at TIMESTAMP,
     finished_at TIMESTAMP,
@@ -162,6 +164,109 @@ class TestHistoryEndpoint(unittest.TestCase):
             with sqlite3.connect(str(self.DB_PATH)) as conn:
                 conn.execute("DELETE FROM publish_details WHERE id = 'd6'")
                 conn.execute("DELETE FROM publish_batches WHERE id = 'b3'")
+                conn.commit()
+
+    def test_history_cover_url_handles_windows_path(self):
+        """thumbnail_path 是 Windows 路径(D:\\...\\data\\materials\\...)时,
+        cover_url 应正确剥前缀返回 materials/2026/... 相对路径。
+
+        场景:数据从用户 Windows 机器同步过来,thumbnail_path 存的是
+        'D:\\work\\AI\\QianFan-Sync\\data\\materials\\2026\\06\\14\\xxx.jpg'。
+        原 _resolve_cover_from_path 正则只识别 Linux '/',Windows 反斜杠
+        匹配不到,fallback 用 os.path.basename 又因 Linux 不识别 '\\' 把
+        整串当 basename,产生 'D%3A%5Cwork%5C...' 的废 URL。
+        """
+        with sqlite3.connect(str(self.DB_PATH)) as conn:
+            conn.execute(
+                "INSERT INTO publish_batches (id, type, title, status, account_count, success_count, failed_count, created_at) "
+                "VALUES ('b4', 'video', 'windows-path', 'success', 1, 1, 0, '2026-06-04 10:00:00')"
+            )
+            conn.execute(
+                "INSERT INTO publish_details (id, batch_id, account_name, platform, account_configs, status) "
+                "VALUES ('d7', 'b4', '账号G', '抖音', ?, 'success')",
+                (json.dumps({
+                    'title': 'windows-path',
+                    'coverLandscape': {'stored_path': 'D:\\work\\AI\\QianFan-Sync\\data\\materials\\2026\\06\\14\\abc.jpg'},
+                    'thumbnail_path': 'D:\\work\\AI\\QianFan-Sync\\data\\materials\\2026\\06\\14\\abc.jpg',
+                }),)
+            )
+            conn.commit()
+
+        try:
+            resp = self.client.get('/api/v2/history?type=video')
+            self.assertEqual(resp.status_code, 200, resp.get_data(as_text=True))
+            target = next((b for b in resp.get_json()['data']['items'] if b['id'] == 'b4'), None)
+            self.assertIsNotNone(target)
+            # 应该剥掉 Windows 前缀,返回纯 materials/... 相对路径
+            self.assertEqual(
+                target['cover_url'],
+                '/api/materials/file/materials%2F2026%2F06%2F14%2Fabc.jpg',
+                f"got: {target['cover_url']}"
+            )
+        finally:
+            with sqlite3.connect(str(self.DB_PATH)) as conn:
+                conn.execute("DELETE FROM publish_details WHERE id = 'd7'")
+                conn.execute("DELETE FROM publish_batches WHERE id = 'b4'")
+                conn.commit()
+
+    def test_history_filters_out_legacy_batches_by_default(self):
+        """默认查询应过滤掉 v0.6.0 旧版本数据(account_configs 不含
+        coverLandscape / videoLandscape 任一新字段且 source 为空)。
+
+        场景:v0.6.0 时代写入的 batch,detail.account_configs 没有任何
+        v0.7.0 新字段。这些数据应该被默认查询过滤掉,避免用户看到
+        封面破损 / 字段不全的历史卡片。
+
+        通过 ?include_legacy=1 可看全部。
+        """
+        # 插一条旧版本数据(account_configs 只含 v0.6.0 字段)
+        # 插一条新版本数据(account_configs 含 coverLandscape)
+        with sqlite3.connect(str(self.DB_PATH)) as conn:
+            conn.execute(
+                "INSERT INTO publish_batches (id, type, title, status, account_count, success_count, failed_count, created_at) "
+                "VALUES ('b_legacy', 'video', 'legacy-batch', 'success', 1, 1, 0, '2026-06-01 10:00:00')"
+            )
+            conn.execute(
+                "INSERT INTO publish_details (id, batch_id, account_name, platform, account_configs, status) "
+                "VALUES ('d_legacy', 'b_legacy', '账号L', '抖音', ?, 'success')",
+                (json.dumps({
+                    # 只有 v0.6.0 字段,没有 coverLandscape / videoLandscape
+                    'title': 'legacy', 'description': '', 'tags': [],
+                    'thumbnailLandscape': 'x', 'thumbnailPortrait': 'y',
+                }),)
+            )
+            conn.execute(
+                "INSERT INTO publish_batches (id, type, title, status, account_count, success_count, failed_count, created_at) "
+                "VALUES ('b_new', 'video', 'new-batch', 'success', 1, 1, 0, '2026-06-05 10:00:00')"
+            )
+            conn.execute(
+                "INSERT INTO publish_details (id, batch_id, account_name, platform, account_configs, status) "
+                "VALUES ('d_new', 'b_new', '账号N', '抖音', ?, 'success')",
+                (json.dumps({
+                    'title': 'new', 'coverLandscape': {'stored_path': '/x.jpg'},
+                    'videoLandscape': {'stored_path': '/v.mp4'},
+                }),)
+            )
+            conn.commit()
+
+        try:
+            # 默认查询:只看到 new-batch
+            resp = self.client.get('/api/v2/history?type=video')
+            self.assertEqual(resp.status_code, 200)
+            ids = [b['id'] for b in resp.get_json()['data']['items']]
+            self.assertIn('b_new', ids)
+            self.assertNotIn('b_legacy', ids, "legacy batch should be filtered by default")
+
+            # include_legacy=1:看到全部
+            resp = self.client.get('/api/v2/history?type=video&include_legacy=1')
+            self.assertEqual(resp.status_code, 200)
+            ids = [b['id'] for b in resp.get_json()['data']['items']]
+            self.assertIn('b_new', ids)
+            self.assertIn('b_legacy', ids, "include_legacy=1 should show all")
+        finally:
+            with sqlite3.connect(str(self.DB_PATH)) as conn:
+                conn.execute("DELETE FROM publish_details WHERE id IN ('d_legacy', 'd_new')")
+                conn.execute("DELETE FROM publish_batches WHERE id IN ('b_legacy', 'b_new')")
                 conn.commit()
 
 


### PR DESCRIPTION
用户反馈页面看到很多 v0.6.0 时代的历史数据(从 Windows 同步过来,
account_configs 字段结构跟 v0.7.0 不一致),希望默认隐藏。

判断标准:batch 至少有一个 detail 的 account_configs 含
v0.7.0 新字段(coverLandscape / videoLandscape),或 batch.source 非空。否则视为旧版本,默认查询过滤掉。

新增 query param ?include_legacy=1 可看全部(包括旧版本)。

同步升级 test_history_endpoint 的 fixture:
- _setup_db 测试数据加 coverLandscape 字段(模拟 v0.7.0 数据格式)
- _SCHEMA_SQL 补 source / draft_id 列(对齐生产 init_db.py)
- 加 test_history_filters_out_legacy_batches_by_default 测试

实际效果:本地 17 batches → 默认查询返回 4 batches(只 v0.7.0 数据), include_legacy=1 返回 17 batches。