### PR TITLE
feat(batch-set): 批量设置新增定时发布字段与全量/增量两种应用模式

### DIFF
--- a/frontend/src/components/BatchSetDialog.vue
+++ b/frontend/src/components/BatchSetDialog.vue
@@ -46,6 +46,17 @@
           </div>
         </div>
       </el-form-item>
+      <el-form-item label="定时发布">
+        <el-date-picker
+          v-model="formScheduleTime"
+          type="datetime"
+          placeholder="留空表示立即发布，选择时间则定时发布"
+          format="YYYY-MM-DD HH:mm:ss"
+          value-format="YYYY-MM-DD HH:mm:ss"
+          clearable
+          style="width: 100%"
+        />
+      </el-form-item>
       <el-form-item label="渠道">
         <div class="channel-grid">
           <div
@@ -76,10 +87,18 @@
       <el-button @click="emit('update:modelValue', false)">取消</el-button>
       <el-button
         type="primary"
+        plain
         :disabled="checkedCount === 0"
-        @click="handleApply"
+        @click="handleApply('partial')"
       >
-        应用到 {{ checkedCount }} 个渠道
+        仅应用已填写
+      </el-button>
+      <el-button
+        type="primary"
+        :disabled="checkedCount === 0"
+        @click="handleApply('full')"
+      >
+        全量应用
       </el-button>
     </template>
   </el-dialog>
@@ -103,6 +122,7 @@ const formTitle = ref('')
 const formDescription = ref('')
 const formTags = ref([])
 const tagInput = ref('')
+const formScheduleTime = ref('')
 const checkedKeys = ref(new Set())
 
 const checkedCount = computed(() => checkedKeys.value.size)
@@ -113,6 +133,7 @@ watch(() => props.modelValue, (open) => {
     formDescription.value = ''
     formTags.value = []
     tagInput.value = ''
+    formScheduleTime.value = ''
     checkedKeys.value = new Set(
       props.platforms.filter(p => p.count > 0).map(p => p.key)
     )
@@ -149,11 +170,14 @@ function removeTag(idx) {
   formTags.value = formTags.value.filter((_, i) => i !== idx)
 }
 
-function handleApply() {
+function handleApply(mode = 'full') {
   emit('apply', Array.from(checkedKeys.value), {
     title: formTitle.value,
     description: formDescription.value,
     tags: [...formTags.value],
+    scheduleTime: formScheduleTime.value || '',
+    // 'full' = 全量覆盖（空值也会清空原值）；'partial' = 仅覆盖已填写字段（空值跳过）
+    mode,
   })
   emit('update:modelValue', false)
 }

--- a/frontend/src/composables/useBatchSetApply.js
+++ b/frontend/src/composables/useBatchSetApply.js
@@ -2,22 +2,37 @@ import { getPlatformByKey } from '@/config/platforms'
 
 /**
  * 视频发布批量设 composable。
- * 把 payload (title/description/tags) 写入 checkedPlatformKeys 中每个渠道的:
+ * 把 payload (title/description/tags/scheduleTime) 写入 checkedPlatformKeys 中每个渠道的:
  *   1) platformConfigs[platformKey] (渠道级, 覆盖)
  *   2) 该渠道下已开 accountChecked 的账号 → accountOverrides[id] (账号级, 覆盖)
  *
+ * 注：视频侧 enableTimer 在发布时由 scheduleTime 派生（PublishCenter.vue 构造 publishData 时
+ *   enableTimer = scheduleTime ? 1 : 0），故此处只写 scheduleTime。
+ *
  * @param {object} refs  { platformConfigs, accountOverrides, accountChecked, accountStore }
- * @returns {{ applyBatchSet: (checkedPlatformKeys: string[], payload: { title: string, description: string, tags: string[] }) => void }}
+ * @returns {{ applyBatchSet: (checkedPlatformKeys: string[], payload: { title: string, description: string, tags: string[], scheduleTime: string }) => void }}
  */
 export function useBatchSetApply({ platformConfigs, accountOverrides, accountChecked, accountStore }) {
   function applyBatchSet(checkedPlatformKeys, payload) {
-    const { title, description, tags } = payload
+    const { title, description, tags, scheduleTime } = payload
+    const mode = payload.mode || 'full'
+    const tagsCopy = Array.isArray(tags) ? [...tags] : []
+    const scheduleTimeValue = scheduleTime || ''
+
+    // partial 模式：仅覆盖已填写（非空）字段，空值字段跳过保持原值
+    const isPartial = mode === 'partial'
+    const hasTitle = title !== undefined && title !== ''
+    const hasDescription = description !== undefined && description !== ''
+    const hasTags = tagsCopy.length > 0
+    const hasScheduleTime = scheduleTimeValue !== ''
+
     for (const pk of checkedPlatformKeys) {
       // 1. 渠道级（覆盖）
       if (!platformConfigs[pk]) platformConfigs[pk] = {}
-      platformConfigs[pk].title = title
-      platformConfigs[pk].description = description
-      platformConfigs[pk].tags = Array.isArray(tags) ? [...tags] : []
+      if (!isPartial || hasTitle) platformConfigs[pk].title = title
+      if (!isPartial || hasDescription) platformConfigs[pk].description = description
+      if (!isPartial || hasTags) platformConfigs[pk].tags = tagsCopy
+      if (!isPartial || hasScheduleTime) platformConfigs[pk].scheduleTime = scheduleTimeValue
 
       // 2. 该渠道下已开 accountChecked 的账号（覆盖）
       const platformCfg = getPlatformByKey(pk)
@@ -26,9 +41,10 @@ export function useBatchSetApply({ platformConfigs, accountOverrides, accountChe
       for (const acc of accounts) {
         if (accountChecked[acc.id]) {
           if (!accountOverrides[acc.id]) accountOverrides[acc.id] = {}
-          accountOverrides[acc.id].title = title
-          accountOverrides[acc.id].description = description
-          accountOverrides[acc.id].tags = Array.isArray(tags) ? [...tags] : []
+          if (!isPartial || hasTitle) accountOverrides[acc.id].title = title
+          if (!isPartial || hasDescription) accountOverrides[acc.id].description = description
+          if (!isPartial || hasTags) accountOverrides[acc.id].tags = tagsCopy
+          if (!isPartial || hasScheduleTime) accountOverrides[acc.id].scheduleTime = scheduleTimeValue
         }
       }
     }

--- a/frontend/src/composables/useImageBatchSetApply.js
+++ b/frontend/src/composables/useImageBatchSetApply.js
@@ -2,13 +2,42 @@
  * 图集发布批量设 composable。
  * 通过 panel.publicApi 调 useChannelForm 扩展的 setPlatformConfig / setAccountOverride。
  *
+ * 注：定时发布同时写 scheduleTime 和 enableTimer（enableTimer 由 scheduleTime 是否非空派生）。
+ *   小红书 panel 的 publishFn 用 `enableTimer ? scheduleTime : ''` 门控，故必须同步写 enableTimer，
+ *   否则批量设的 scheduleTime 会被小红书的开关（默认 false）清空。
+ *
  * @param {object} refs  { panels: Map<string, panelRef> } — panels 用 platformKey 索引
- * @returns {{ applyImageBatchSet: (checkedPlatformKeys: string[], payload: { title: string, description: string, tags: string[] }) => void }}
+ * @returns {{ applyImageBatchSet: (checkedPlatformKeys: string[], payload: { title: string, description: string, tags: string[], scheduleTime: string }) => void }}
  */
 export function useImageBatchSetApply({ panels }) {
   function applyImageBatchSet(checkedPlatformKeys, payload) {
-    const { title, description, tags } = payload
+    const { title, description, tags, scheduleTime } = payload
+    const mode = payload.mode || 'full'
     const tagsCopy = Array.isArray(tags) ? [...tags] : []
+    const scheduleTimeValue = scheduleTime || ''
+    // 定时开关由 scheduleTime 是否非空派生：选了时间→true，留空→false（立即发布）
+    const enableTimerValue = !!scheduleTimeValue
+
+    // partial 模式：仅覆盖已填写（非空）字段；未填写的字段不传（setPlatformConfig
+    // / setAccountOverride 遇到 undefined 会自动跳过，保持 panel 原值）
+    const isPartial = mode === 'partial'
+    const hasTitle = title !== undefined && title !== ''
+    const hasDescription = description !== undefined && description !== ''
+    const hasTags = tagsCopy.length > 0
+    const hasScheduleTime = scheduleTimeValue !== ''
+
+    // 构造要写入的字段集合：full 模式全量，partial 模式仅含已填写字段
+    function buildFields() {
+      return {
+        ...(isPartial ? (hasTitle ? { title } : {}) : { title }),
+        ...(isPartial ? (hasDescription ? { description } : {}) : { description }),
+        ...(isPartial ? (hasTags ? { tags: tagsCopy } : {}) : { tags: tagsCopy }),
+        ...(isPartial
+          ? (hasScheduleTime ? { scheduleTime: scheduleTimeValue, enableTimer: enableTimerValue } : {})
+          : { scheduleTime: scheduleTimeValue, enableTimer: enableTimerValue }),
+      }
+    }
+
     for (const pk of checkedPlatformKeys) {
       const panel = panels.get?.(pk) || panels[pk]
       // panel 组件用 defineExpose(publicApi) 直接展开方法,所以方法在 panel 上而非 panel.publicApi 下
@@ -16,21 +45,18 @@ export function useImageBatchSetApply({ panels }) {
       const api = panel?.publicApi || panel
       if (!api?.setPlatformConfig) continue
 
+      const fields = buildFields()
+      // partial 模式下用户可能一个字段都没填，此时 fields 为空，跳过该渠道
+      // （避免 setAccountOverride({}) 误删已有 override）
+      if (isPartial && Object.keys(fields).length === 0) continue
+
       // 1. 写 panel 内的 platformConfig（覆盖）
-      api.setPlatformConfig({
-        title,
-        description,
-        tags: tagsCopy,
-      })
+      api.setPlatformConfig(fields)
 
       // 2. 写该 panel 下已个性化账号（覆盖）
       const checkedIds = api.getCheckedAccountIds?.() || []
       for (const aid of checkedIds) {
-        api.setAccountOverride(aid, {
-          title,
-          description,
-          tags: tagsCopy,
-        })
+        api.setAccountOverride(aid, fields)
       }
     }
   }


### PR DESCRIPTION
BatchSetDialog 新增「定时发布」时间选择器（留空=立即发布，选时间=定时），
payload 增加 scheduleTime 字段。

底部按钮拆为两个：
- 全量应用（原逻辑）：表单内容原样覆盖，空值会清空原值
- 仅应用已填写（新增）：只覆盖有内容的字段，空值跳过保持原值 两个按钮分别用主色实心 / 主色描边区分主次。

useBatchSetApply（视频侧）：渠道级与账号级均写入 scheduleTime；
视频侧 enableTimer 发布时由 scheduleTime 派生，无需额外处理。
支持 mode=partial，空值字段跳过。

useImageBatchSetApply（图文侧）：写入 scheduleTime 同时派生
enableTimer（解决小红书 publishFn 的 enableTimer 门控）；
partial 模式下仅传已填字段，未填不传（依赖 panel API 的 undefined 跳过）， 用户全未填时跳过整个渠道避免误删已有 override。