### PR TITLE
fix(scripts): 修复 macOS 启动脚本就绪检测

### DIFF
--- a/start-beta.sh
+++ b/start-beta.sh
@@ -30,11 +30,36 @@ if [[ -d "$DEP_BIN_DIR" ]]; then
     export PATH="$DEP_BIN_DIR:$DEP_DIR/python/bin:$DEP_DIR/git/bin:$DEP_DIR/node/bin:$PATH"
 fi
 
-# CloakBrowser: 如果 dependency/cloakbrowser/ 下有 chrome 二进制，优先使用
+find_cloakbrowser_binary() {
+    local base_dir="$1"
+    local candidate
+
+    if [[ ! -d "$base_dir" ]]; then
+        return 1
+    fi
+
+    for candidate in \
+        "$base_dir/chrome" \
+        "$base_dir/chrome-bin/chrome" \
+        "$base_dir/Chromium.app/Contents/MacOS/Chromium" \
+        "$base_dir"/chromium-*/chrome \
+        "$base_dir"/chromium-*/chrome-bin/chrome \
+        "$base_dir"/chromium-*/Chromium.app/Contents/MacOS/Chromium; do
+        if [[ -f "$candidate" ]]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+# CloakBrowser: 如果 dependency/cloakbrowser/ 下有浏览器二进制，优先使用
 CLOAKBROWSER_LOCAL="$DEP_DIR/cloakbrowser"
-if [[ -f "$CLOAKBROWSER_LOCAL/chrome" ]]; then
-    export CLOAKBROWSER_BINARY_PATH="$CLOAKBROWSER_LOCAL/chrome"
+if _chrome_bin=$(find_cloakbrowser_binary "$CLOAKBROWSER_LOCAL"); then
+    export CLOAKBROWSER_BINARY_PATH="$_chrome_bin"
 fi
+unset _chrome_bin
 
 # --- 项目代码管理（git clone / update）---
 REPO_URL="https://github.com/DevilJie/social-auto-upload-web-ui.git"
@@ -375,7 +400,7 @@ fi
 CLOAKBROWSER_DIR="$HOME/.cloakbrowser"
 if [[ -n "${CLOAKBROWSER_BINARY_PATH:-}" ]]; then
     print_ok "CloakBrowser (本地依赖)"
-elif ! ls "$CLOAKBROWSER_DIR"/chromium-*/chrome >/dev/null 2>&1; then
+elif ! _chrome_bin=$(find_cloakbrowser_binary "$CLOAKBROWSER_DIR"); then
     echo -e "  ${CYAN}📥 首次使用，下载 CloakBrowser 浏览器${NC}"
 
     # 从 Python 获取下载信息
@@ -396,7 +421,10 @@ print(d.get_binary_path())
     fi
 
     # 使用 curl 下载（带进度条）
-    TMP_FILE=$(mktemp /tmp/cloakbrowser-XXXXXX.tar.gz)
+    # macOS 的 mktemp 不接受模板中有非 X 字符（如 .tar.gz 后缀），
+    # 先建临时目录，文件放在目录里（路径兼容 Linux 和 macOS）。
+    TMP_DIR=$(mktemp -d /tmp/cloakbrowser-XXXXXX)
+    TMP_FILE="$TMP_DIR/cloakbrowser.archive"
     echo -e "  ${CYAN}⬇  下载地址: ${DOWNLOAD_URL}${NC}"
     echo ""
 
@@ -406,7 +434,7 @@ print(d.get_binary_path())
         echo ""
         echo -e "  ${WARN} 主下载失败，尝试 GitHub 备用地址..."
         if ! curl -L -# -o "$TMP_FILE" "$GITHUB_URL"; then
-            rm -f "$TMP_FILE"
+            rm -rf "$TMP_DIR"
             print_fail "CloakBrowser 下载失败，请检查网络连接"
             exit 1
         fi
@@ -416,20 +444,27 @@ print(d.get_binary_path())
     echo ""
     echo -n -e "  ${CYAN}📦 解压中...${NC}"
     mkdir -p "$BINARY_DIR"
-    tar -xzf "$TMP_FILE" -C "$BINARY_DIR" 2>/dev/null
-    rm -f "$TMP_FILE"
-
-    # 确保二进制文件可执行
-    chmod +x "$BINARY_PATH" 2>/dev/null
-    chmod +x "$BINARY_DIR"/chrome-bin/chrome 2>/dev/null
-
-    if [[ -f "$BINARY_PATH" ]] || ls "$BINARY_DIR"/chrome-bin/chrome >/dev/null 2>&1; then
-        printf "\r  ${CHECK} CloakBrowser 下载完成\n"
-    else
+    if ! tar -xzf "$TMP_FILE" -C "$BINARY_DIR"; then
+        rm -rf "$TMP_DIR"
         printf "\r  ${CROSS} CloakBrowser 解压失败\n"
         exit 1
     fi
+    rm -rf "$TMP_DIR"
+
+    # 确保实际存在的二进制文件可执行
+    if _chrome_bin=$(find_cloakbrowser_binary "$BINARY_DIR"); then
+        chmod +x "$_chrome_bin" 2>/dev/null || true
+        export CLOAKBROWSER_BINARY_PATH="$_chrome_bin"
+        printf "\r  ${CHECK} CloakBrowser 下载完成\n"
+    else
+        printf "\r  ${CROSS} CloakBrowser 解压失败\n"
+        print_warn "未找到 CloakBrowser 二进制文件: chrome、chrome-bin/chrome 或 Chromium.app/Contents/MacOS/Chromium"
+        exit 1
+    fi
+    unset _chrome_bin
 else
+    export CLOAKBROWSER_BINARY_PATH="$_chrome_bin"
+    unset _chrome_bin
     print_ok "CloakBrowser 已安装"
 fi
 
@@ -539,7 +574,12 @@ done
 
 echo -n "  等待前端就绪"
 for i in $(seq 1 30); do
-    http_code=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:5173" 2>/dev/null || true)
+    # Vite 在 macOS 上可能只监听 localhost 的 IPv6 地址（::1），不监听 127.0.0.1。
+    # 使用 --noproxy 避免本机代理把 localhost 请求转走导致误判。
+    http_code=$(curl --noproxy '*' -s -o /dev/null -w "%{http_code}" "http://localhost:5173" 2>/dev/null || true)
+    if [[ "$http_code" != "200" ]]; then
+        http_code=$(curl --noproxy '*' -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:5173" 2>/dev/null || true)
+    fi
     if [[ "$http_code" == "200" ]]; then
         echo ""
         print_ok "前端就绪"

--- a/start-macos.sh
+++ b/start-macos.sh
@@ -30,14 +30,34 @@ if [[ -d "$DEP_BIN_DIR" ]]; then
     export PATH="$DEP_BIN_DIR:$DEP_DIR/python/bin:$DEP_DIR/git/bin:$DEP_DIR/node/bin:$PATH"
 fi
 
-# CloakBrowser: 如果 dependency/cloakbrowser/ 下有 chrome 二进制，优先使用
-# （递归查找：chrome 可能直接在根目录，也可能在 chromium-*/chrome、chrome-bin/chrome）
-CLOAKBROWSER_LOCAL="$DEP_DIR/cloakbrowser"
-if [[ -d "$CLOAKBROWSER_LOCAL" ]]; then
-    _chrome_bin=$(find "$CLOAKBROWSER_LOCAL" -name "chrome" -type f -print -quit 2>/dev/null || true)
-    if [[ -n "$_chrome_bin" ]]; then
-        export CLOAKBROWSER_BINARY_PATH="$_chrome_bin"
+find_cloakbrowser_binary() {
+    local base_dir="$1"
+    local candidate
+
+    if [[ ! -d "$base_dir" ]]; then
+        return 1
     fi
+
+    for candidate in \
+        "$base_dir/chrome" \
+        "$base_dir/chrome-bin/chrome" \
+        "$base_dir/Chromium.app/Contents/MacOS/Chromium" \
+        "$base_dir"/chromium-*/chrome \
+        "$base_dir"/chromium-*/chrome-bin/chrome \
+        "$base_dir"/chromium-*/Chromium.app/Contents/MacOS/Chromium; do
+        if [[ -f "$candidate" ]]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+# CloakBrowser: 如果 dependency/cloakbrowser/ 下有浏览器二进制，优先使用
+CLOAKBROWSER_LOCAL="$DEP_DIR/cloakbrowser"
+if _chrome_bin=$(find_cloakbrowser_binary "$CLOAKBROWSER_LOCAL"); then
+    export CLOAKBROWSER_BINARY_PATH="$_chrome_bin"
 fi
 unset _chrome_bin
 
@@ -380,7 +400,7 @@ fi
 CLOAKBROWSER_DIR="$HOME/.cloakbrowser"
 if [[ -n "${CLOAKBROWSER_BINARY_PATH:-}" ]]; then
     print_ok "CloakBrowser (本地依赖)"
-elif ! ls "$CLOAKBROWSER_DIR"/chromium-*/chrome >/dev/null 2>&1; then
+elif ! _chrome_bin=$(find_cloakbrowser_binary "$CLOAKBROWSER_DIR"); then
     echo -e "  ${CYAN}📥 首次使用，下载 CloakBrowser 浏览器${NC}"
 
     # 从 Python 获取下载信息
@@ -424,20 +444,27 @@ print(d.get_binary_path())
     echo ""
     echo -n -e "  ${CYAN}📦 解压中...${NC}"
     mkdir -p "$BINARY_DIR"
-    tar -xzf "$TMP_FILE" -C "$BINARY_DIR" 2>/dev/null
-    rm -rf "$TMP_DIR"
-
-    # 确保二进制文件可执行
-    chmod +x "$BINARY_PATH" 2>/dev/null
-    chmod +x "$BINARY_DIR"/chrome-bin/chrome 2>/dev/null
-
-    if [[ -f "$BINARY_PATH" ]] || ls "$BINARY_DIR"/chrome-bin/chrome >/dev/null 2>&1; then
-        printf "\r  ${CHECK} CloakBrowser 下载完成\n"
-    else
+    if ! tar -xzf "$TMP_FILE" -C "$BINARY_DIR"; then
+        rm -rf "$TMP_DIR"
         printf "\r  ${CROSS} CloakBrowser 解压失败\n"
         exit 1
     fi
+    rm -rf "$TMP_DIR"
+
+    # 确保实际存在的二进制文件可执行
+    if _chrome_bin=$(find_cloakbrowser_binary "$BINARY_DIR"); then
+        chmod +x "$_chrome_bin" 2>/dev/null || true
+        export CLOAKBROWSER_BINARY_PATH="$_chrome_bin"
+        printf "\r  ${CHECK} CloakBrowser 下载完成\n"
+    else
+        printf "\r  ${CROSS} CloakBrowser 解压失败\n"
+        print_warn "未找到 CloakBrowser 二进制文件: chrome、chrome-bin/chrome 或 Chromium.app/Contents/MacOS/Chromium"
+        exit 1
+    fi
+    unset _chrome_bin
 else
+    export CLOAKBROWSER_BINARY_PATH="$_chrome_bin"
+    unset _chrome_bin
     print_ok "CloakBrowser 已安装"
 fi
 
@@ -547,7 +574,12 @@ done
 
 echo -n "  等待前端就绪"
 for i in $(seq 1 30); do
-    http_code=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:5173" 2>/dev/null || true)
+    # Vite 在 macOS 上可能只监听 localhost 的 IPv6 地址（::1），不监听 127.0.0.1。
+    # 使用 --noproxy 避免本机代理把 localhost 请求转走导致误判。
+    http_code=$(curl --noproxy '*' -s -o /dev/null -w "%{http_code}" "http://localhost:5173" 2>/dev/null || true)
+    if [[ "$http_code" != "200" ]]; then
+        http_code=$(curl --noproxy '*' -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:5173" 2>/dev/null || true)
+    fi
     if [[ "$http_code" == "200" ]]; then
         echo ""
         print_ok "前端就绪"

--- a/start.sh
+++ b/start.sh
@@ -30,11 +30,36 @@ if [[ -d "$DEP_BIN_DIR" ]]; then
     export PATH="$DEP_BIN_DIR:$DEP_DIR/python/bin:$DEP_DIR/git/bin:$DEP_DIR/node/bin:$PATH"
 fi
 
-# CloakBrowser: 如果 dependency/cloakbrowser/ 下有 chrome 二进制，优先使用
+find_cloakbrowser_binary() {
+    local base_dir="$1"
+    local candidate
+
+    if [[ ! -d "$base_dir" ]]; then
+        return 1
+    fi
+
+    for candidate in \
+        "$base_dir/chrome" \
+        "$base_dir/chrome-bin/chrome" \
+        "$base_dir/Chromium.app/Contents/MacOS/Chromium" \
+        "$base_dir"/chromium-*/chrome \
+        "$base_dir"/chromium-*/chrome-bin/chrome \
+        "$base_dir"/chromium-*/Chromium.app/Contents/MacOS/Chromium; do
+        if [[ -f "$candidate" ]]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+# CloakBrowser: 如果 dependency/cloakbrowser/ 下有浏览器二进制，优先使用
 CLOAKBROWSER_LOCAL="$DEP_DIR/cloakbrowser"
-if [[ -f "$CLOAKBROWSER_LOCAL/chrome" ]]; then
-    export CLOAKBROWSER_BINARY_PATH="$CLOAKBROWSER_LOCAL/chrome"
+if _chrome_bin=$(find_cloakbrowser_binary "$CLOAKBROWSER_LOCAL"); then
+    export CLOAKBROWSER_BINARY_PATH="$_chrome_bin"
 fi
+unset _chrome_bin
 
 # --- 项目代码管理（git clone / update）---
 REPO_URL="https://github.com/DevilJie/social-auto-upload-web-ui.git"
@@ -375,7 +400,7 @@ fi
 CLOAKBROWSER_DIR="$HOME/.cloakbrowser"
 if [[ -n "${CLOAKBROWSER_BINARY_PATH:-}" ]]; then
     print_ok "CloakBrowser (本地依赖)"
-elif ! ls "$CLOAKBROWSER_DIR"/chromium-*/chrome >/dev/null 2>&1; then
+elif ! _chrome_bin=$(find_cloakbrowser_binary "$CLOAKBROWSER_DIR"); then
     echo -e "  ${CYAN}📥 首次使用，下载 CloakBrowser 浏览器${NC}"
 
     # 从 Python 获取下载信息
@@ -396,7 +421,10 @@ print(d.get_binary_path())
     fi
 
     # 使用 curl 下载（带进度条）
-    TMP_FILE=$(mktemp /tmp/cloakbrowser-XXXXXX.tar.gz)
+    # macOS 的 mktemp 不接受模板中有非 X 字符（如 .tar.gz 后缀），
+    # 先建临时目录，文件放在目录里（路径兼容 Linux 和 macOS）。
+    TMP_DIR=$(mktemp -d /tmp/cloakbrowser-XXXXXX)
+    TMP_FILE="$TMP_DIR/cloakbrowser.archive"
     echo -e "  ${CYAN}⬇  下载地址: ${DOWNLOAD_URL}${NC}"
     echo ""
 
@@ -406,7 +434,7 @@ print(d.get_binary_path())
         echo ""
         echo -e "  ${WARN} 主下载失败，尝试 GitHub 备用地址..."
         if ! curl -L -# -o "$TMP_FILE" "$GITHUB_URL"; then
-            rm -f "$TMP_FILE"
+            rm -rf "$TMP_DIR"
             print_fail "CloakBrowser 下载失败，请检查网络连接"
             exit 1
         fi
@@ -416,20 +444,27 @@ print(d.get_binary_path())
     echo ""
     echo -n -e "  ${CYAN}📦 解压中...${NC}"
     mkdir -p "$BINARY_DIR"
-    tar -xzf "$TMP_FILE" -C "$BINARY_DIR" 2>/dev/null
-    rm -f "$TMP_FILE"
-
-    # 确保二进制文件可执行
-    chmod +x "$BINARY_PATH" 2>/dev/null
-    chmod +x "$BINARY_DIR"/chrome-bin/chrome 2>/dev/null
-
-    if [[ -f "$BINARY_PATH" ]] || ls "$BINARY_DIR"/chrome-bin/chrome >/dev/null 2>&1; then
-        printf "\r  ${CHECK} CloakBrowser 下载完成\n"
-    else
+    if ! tar -xzf "$TMP_FILE" -C "$BINARY_DIR"; then
+        rm -rf "$TMP_DIR"
         printf "\r  ${CROSS} CloakBrowser 解压失败\n"
         exit 1
     fi
+    rm -rf "$TMP_DIR"
+
+    # 确保实际存在的二进制文件可执行
+    if _chrome_bin=$(find_cloakbrowser_binary "$BINARY_DIR"); then
+        chmod +x "$_chrome_bin" 2>/dev/null || true
+        export CLOAKBROWSER_BINARY_PATH="$_chrome_bin"
+        printf "\r  ${CHECK} CloakBrowser 下载完成\n"
+    else
+        printf "\r  ${CROSS} CloakBrowser 解压失败\n"
+        print_warn "未找到 CloakBrowser 二进制文件: chrome、chrome-bin/chrome 或 Chromium.app/Contents/MacOS/Chromium"
+        exit 1
+    fi
+    unset _chrome_bin
 else
+    export CLOAKBROWSER_BINARY_PATH="$_chrome_bin"
+    unset _chrome_bin
     print_ok "CloakBrowser 已安装"
 fi
 
@@ -539,7 +574,12 @@ done
 
 echo -n "  等待前端就绪"
 for i in $(seq 1 30); do
-    http_code=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:5173" 2>/dev/null || true)
+    # Vite 在 macOS 上可能只监听 localhost 的 IPv6 地址（::1），不监听 127.0.0.1。
+    # 使用 --noproxy 避免本机代理把 localhost 请求转走导致误判。
+    http_code=$(curl --noproxy '*' -s -o /dev/null -w "%{http_code}" "http://localhost:5173" 2>/dev/null || true)
+    if [[ "$http_code" != "200" ]]; then
+        http_code=$(curl --noproxy '*' -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:5173" 2>/dev/null || true)
+    fi
     if [[ "$http_code" == "200" ]]; then
         echo ""
         print_ok "前端就绪"


### PR DESCRIPTION
## 问题原因

macOS 下启动脚本存在两个容易导致误判/静默退出的问题：

1. CloakBrowser 的 macOS 包内二进制位于 `Chromium.app/Contents/MacOS/Chromium`，但脚本只按 `chrome` / `chrome-bin/chrome` 路径检测。下载解压后，脚本在 `set -euo pipefail` 下无条件执行 `chmod +x "$BINARY_DIR"/chrome-bin/chrome 2>/dev/null`，该路径不存在时 `chmod` 返回非 0，错误又被重定向吞掉，导致用户只看到“解压中...”后脚本静默退出。
2. Vite 在 macOS 上可能只监听 `localhost` 的 IPv6 地址 `::1`，不监听 `127.0.0.1`。原脚本只请求 `http://127.0.0.1:5173`，会在前端实际已启动时仍判断为“前端启动超时”。如果本机配置了代理，也可能进一步干扰 localhost 探测。

## 修复内容

- 新增 `find_cloakbrowser_binary`，统一支持以下 CloakBrowser 候选路径：
  - `chrome`
  - `chrome-bin/chrome`
  - `Chromium.app/Contents/MacOS/Chromium`
  - `chromium-*/chrome`
  - `chromium-*/chrome-bin/chrome`
  - `chromium-*/Chromium.app/Contents/MacOS/Chromium`
- 统一 `start.sh`、`start-macos.sh`、`start-beta.sh` 的本地依赖检测、已安装检测和解压后校验逻辑。
- 解压后只对实际找到的二进制执行 `chmod +x`，避免不存在路径触发 `set -e` 静默退出。
- `tar` 解压失败时保留原始错误输出，并显式打印 `CloakBrowser 解压失败`。
- `start.sh` / `start-beta.sh` 同步使用兼容 macOS 的临时目录下载写法。
- 前端就绪检测优先请求 `http://localhost:5173`，失败后再回退到 `http://127.0.0.1:5173`，并使用 `curl --noproxy '*'` 避免本机代理导致误判。

## 验证

- `bash -n start.sh`
- `bash -n start-macos.sh`
- `bash -n start-beta.sh`
- 当前 macOS 环境中已有 `~/.cloakbrowser/chromium-145.0.7632.109.2/Chromium.app/Contents/MacOS/Chromium`，运行 `start-macos.sh` 可正确输出 `CloakBrowser 已安装` 并继续后续步骤。
- 验证 `curl --noproxy '*' http://localhost:5173` 返回 `200`，而 `127.0.0.1:5173` 在当前环境返回 `000`，确认前端超时属于 IPv6 localhost 监听导致的误判。
- 受控运行 `start-macos.sh`，确认可通过 `前端就绪` 检测；验证结束后确认 5409、5173、5410 无遗留进程。
- CCG 变更校验：通过。
- CCG 代码质量校验：通过。
