### PR TITLE
fix(publish): 关浏览器自动取消发布 + postVideo 4小时超时 + 启动脚本检测VC++运行时

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1053,6 +1053,10 @@ def postVideo():
             return jsonify({"code": 200, "msg": "发布任务已提交", "data": None}), 200
         else:
             return jsonify({"code": 500, "msg": "发布失败：页面未跳转，表单校验未通过", "data": None}), 500
+    except asyncio.CancelledError:
+        # 用户手动关闭了浏览器 → create_browser 的 disconnected 监听 cancel 了 task
+        logger.info("发布视频被取消：用户关闭了浏览器")
+        return jsonify({"code": 500, "msg": "用户关闭了浏览器，发布已取消"}), 500
     except Exception as e:
         logger.info(f"发布视频时出错: {str(e)}")
         return jsonify({"code": 500, "msg": f"发布失败: {str(e)}", "data": None}), 500

--- a/backend/impl/_browser.py
+++ b/backend/impl/_browser.py
@@ -41,8 +41,9 @@ async def create_browser(
 
     不接 proxy / extra_args —— 历史代理配置已废弃。
 
-    login_mode=True 时，自动监听浏览器关闭事件：用户手动关浏览器会
-    cancel 当前 asyncio task，使 login 流程立即终止。
+    login_mode=True 或 headless=False（有头）时，自动监听浏览器关闭
+    事件：用户手动关浏览器会 cancel 当前 asyncio task，使 login/发布
+    流程立即终止并返回失败。
 
     humanize=True 时启用 CloakBrowser 拟人化操作层（贝塞尔鼠标轨迹、
     逐键打字、平滑滚动等），仅建议在发布动作开启——会让操作明显变慢，
@@ -59,12 +60,14 @@ async def create_browser(
         human_preset=human_preset,
     )
 
-    if login_mode:
+    if login_mode or headless is False:
+        # login 或有头浏览器（发布场景）：用户关浏览器 → cancel 当前 task，
+        # 使 login/发布流程立即终止，避免后端 worker 一直阻塞。
         task = asyncio.current_task()
 
         def _on_browser_closed():
             if task and not task.done():
-                logger.info("[browser] 用户关闭了登录浏览器，取消 login task")
+                logger.info("[browser] 用户关闭了浏览器，取消当前任务")
                 task.cancel()
 
         browser.on("disconnected", _on_browser_closed)

--- a/frontend/src/views/PublishCenter.vue
+++ b/frontend/src/views/PublishCenter.vue
@@ -2247,7 +2247,9 @@ async function publishAll() {
       if (group.key === 'toutiao') {
         console.log('[PublishCenter.publish] 今日头条参数: extendLink=' + publishData.extendLink + ' extendLinkUrl=' + publishData.extendLinkUrl + ' enableGenerateImage=' + publishData.enableGenerateImage + ' collection=' + publishData.collection)
       }
-      await http.post('/postVideo', publishData)
+      // 视频上传+发布可能很久（大文件/慢网/人机校验），设 4 小时超时
+      // 避免浏览器层提前断开导致「前端判失败但后端仍在跑」
+      await http.post('/postVideo', publishData, { timeout: 4 * 60 * 60 * 1000 })
       publishResults.value.push({
         label: account.name,
         status: 'success',

--- a/pr.md
+++ b/pr.md
@@ -1,138 +1,145 @@
-# 发布历史重设计 + 一键填写封面修复 — v0.6.0
+# CSDN 平台接入 + Cookie 一键导入 15 平台 + 批量检查稳定性修复 — v1.2.0
 
 ## 概述
 
-将发布历史从 4 张零散表（`publish_tasks` / `publish_logs` / `image_publish_tasks` / `image_publish_logs`）合并为统一的主-子表结构（`publish_batches` + `publish_details`），并把 `PublishHistory.vue` 从平铺表格重写为按"批次"分组的卡片式 UI。同步修了一键填写对话框的封面图 bug、账号不复原 bug、表单没填上的 bug，并把 S3 视频下载缓存纳入了系统设置的"缓存清理"功能。
+本次迭代围绕「账号接入效率」展开，做了三件事：**① 接入 CSDN 创作平台**（登录 + 视频发布）；**② 把 cookie 字符串一键导入账号的能力从 2 个平台扩展到全部 15 个**，并重设计了导入弹窗 UI；**③ 修复账号管理「批量检查」功能导致后端假死的严重 bug**。同时统一了 CSDN/知乎的资料同步为无头模式，CSDN 的 cookie 导入按真实多子域结构智能推断 domain/secure/httpOnly 属性。
 
 ---
 
 ## PR 类型
 
-- [x] Breaking change（schema 重构）
-- [x] 新功能（卡片 UI、S3 缓存清理）
-- [x] Bug 修复（封面 bug、账号复原、表单填入、get_stats 500、测试隔离）
-- [ ] 文档（changelog、pr.md、spec/plan）
+- [x] 新功能（CSDN 平台接入、15 平台 cookie 导入、导入弹窗重设计）
+- [x] Bug 修复（批量检查后端假死、检查弹窗不显示、CSDN cookie 登录态丢失）
+- [x] 工程效率（启动脚本强制更新）
+- [x] 文档（v1.2.0 更新日志）
 
 ---
 
 ## 核心变更
 
-### 1. 数据模型（`backend/init_db.py`）
+### 1. CSDN 创作平台接入（`backend/impl/csdn/`）
 
-- **删除**：`publish_tasks` / `publish_logs` / `image_publish_tasks` / `image_publish_logs` 共 4 张旧表
-- **新增**：
-  - `publish_batches`（主表）：每次"发布"=1 行，存标题/描述/封面素材 ID/视频素材 ID/图文素材 ID 集/整体状态/账号数
-  - `publish_details`（明细表）：每账号 1 行，FK→`publish_batches.id`，存平台/账号/状态/错误信息/`publish_url`（预留字段）
-- **索引**：`publish_batches.created_at`、`publish_batches.status`、`publish_details.batch_id`、`publish_details.status`、`publish_details.platform`
-- 不做数据迁移（功能尚未正式使用）
+- 新增 `CsdnPlatform`（platform_id=15），继承 `BasePlatform`，注册到 `registry.py`
+- **登录**：打开 `mp.csdn.net` 创作者首页，用户在可见浏览器手动登录，检测到 `div.user-info-box` 出现即视为登录成功
+- **check_cookie**：headless 访问创作者首页，判断用户信息卡是否存在
+- **sync_profile**：从 `div.user-info-box` 抓昵称（`p.name` 的 title 属性）+ 头像
+- **publish_video**：完整的视频发布流程
+  - 上传视频文件（定位 `input[type=file][accept*=video]`）
+  - 等待「上传成功」文案（`.gement li.text`）
+  - 设置封面（隐藏 input + 裁剪弹窗确认）
+  - 填写标题（≤30 字）、简介（≤150 字）、标签（≤3 个，输入+回车激活）
+  - 可选「是否推荐」勾选
+  - 点击发布按钮，页面跳转即成功
+- 视频限制常量：`CSDN_MAX_TAGS=3` / `CSDN_MAX_TITLE_LEN=30` / `CSDN_MAX_DESC_LEN=150`，同步到 `videoLimits.js`
+- 前端 logo + platforms.js 配置接入
 
-### 2. 后端读取端点
+### 2. Cookie 字符串一键导入 — 扩展到全部 15 平台
 
-- `GET /api/v2/history`：按 `publish_batches` 分组返回，每项含 `items[]` 明细子数组；支持 `type` / `status` / `timeRange` 过滤 + 分页
-- `GET /api/v2/publish-templates`：读 `publish_batches` 中至少部分成功的批次，按 `account_configs` 非空过滤；`thumbnail_path` 解析为 `materials.stored_path`（commit `4152de1` 修复）
-- `GET /api/v2/tasks`（TaskCenter 用）：从 `publish_details` 读，含 `batch_id` 关联 + `batch_title` 字段
-- `GET /api/materials/{id}`（新增，供一键填写封面修复用）
-- `GET /api/v2/stats` 修复（commit `b4d16e6`）：原来 8 个查询都引用旧表，已改读新表，stat cards 恢复显示
+#### 后端：抽象到 BasePlatform，子类 3 行接入
 
-### 3. 后端写入端点
+- `BasePlatform` 新增 `supports_cookie_import` / `platform_cookie_domain` 类属性 + `_parse_cookie_to_storage_state` hook
+- `BasePlatform.import_cookie` 默认实现，封装完整 4 步进度流程：
+  1. **解析 cookie 字符串**（子类 hook）
+  2. **生成 storage_state JSON**（先不写 user_info，验证有效性）
+  3. **sync_profile** 抓取真实昵称/头像（复用账号列表「同步」按钮的同一调用）
+  4. **创建账号记录**（写入 user_info；cookie 失效则清理临时文件并报错）
+- **15 个平台全部接入**，各平台只需声明 `supports_cookie_import = True` + `platform_cookie_domain` + `_parse_cookie_to_storage_state`：
 
-- `POST /postVideo`：`_before_publish` 插 1 batch + 1 detail；`_after_publish` 聚合 batch 状态
-- `POST /api/image-publish/publish`：单账号 + `batchId` 入参；不再插 `image_publish_tasks`/`image_publish_logs`
-- `POST /api/image-publish/drafts/execute-publish`：同步新表
-- `task_queue.py`：`PublishTask` 加 `batch_id` 字段；`_insert_db` / `_update_db` 重写
-- 全部接受新参数：`batchId` / `videoMaterialId` / `landscapeCoverMaterialId` / `portraitCoverMaterialId` / `accountId`
-- `thumbnailLandscape` / `thumbnailPortrait` 存进 `account_configs` JSON（commit `49bd6de` 修复），供 `_resolve_cover_url` 在 material_id 缺失时回退
+  | 平台 | cookie domain |
+  |------|--------------|
+  | 小红书 | `.xiaohongshu.com` |
+  | 视频号 | `.qq.com` |
+  | 抖音 | `.douyin.com` |
+  | 快手 | `.kuaishou.com` |
+  | B站 | `.bilibili.com` |
+  | 百家号 | `.baidu.com` |
+  | TikTok | `.tiktok.com` |
+  | YouTube | `.youtube.com` |
+  | 腾讯视频 | `.qq.com` |
+  | 爱奇艺 | `.iqiyi.com` |
+  | 微博 | `.weibo.com` |
+  | 支付宝 | `.alipay.com` |
+  | 今日头条 | `.toutiao.com` |
+  | 知乎 | `.zhihu.com` |
+  | CSDN | `.csdn.net` |
 
-### 4. 前端改造
+#### CSDN 专属：智能推断 cookie 属性
 
-- **`PublishHistory.vue` 完全重写**：从 `<el-table>` 改为卡片列表（封面+标题+描述+账号汇总+状态徽标+时间），点击展开内联明细（账号/平台/耗时/状态/错误/publish_url）；stat cards / filter / pagination 全部保留，加了 `typeFilter`（视频/图文/全部）
-- **`PublishCenter.vue`**：`publishAll()` 入口生成 UUID 作为 `batchId`；每次 `/postVideo` 调用带上 `batchId` + 3 个素材 ID + `accountId`
-- **`ImagePublish.vue` + 3 个 panel + `useChannelForm.js`**：循环 N 个账号，每次调 `/api/image-publish/publish`（单账号 + 共享 `batchId`）
-- **`OneClickFillDialog.vue`**：封面 URL 改为走 `/api/materials/file/{path}`（之前是 `/uploads/...` 不通）
-- **`TaskCenter.vue`**：字段名 `title` → `batch_title` 适配
-- **`api/v2.js`**：`historyApi` 注释更新
-- **`platforms.js`**：加 `platformNameToKey` 映射（一键填写按平台填 platformConfigs 时用）
-- **`Settings.vue`**：缓存管理新增"S3 视频缓存"项
+- CSDN 的登录态 cookie 散落在多个子域（`.csdn.net` / `passport.csdn.net` / `msg.csdn.net` 等），纯 `k=v` 字符串不带 domain/secure/httpOnly 信息
+- `_parse_cookie_to_storage_state` 重写，维护从真实文件 dump 得到的属性映射表：
+  - waf 系列（`https_waf_cookie`/`waf_captcha_marker`）分到 `passport.csdn.net`
+  - `SESSION` 复制一份到 `msg.csdn.net`
+  - `httpOnly`/`secure` 按真实登录态精确设置（不再一刀切 True/False）
 
-### 5. 一键填写 bug 修复（四个串联 bug）
+#### 前端：导入弹窗 UI 重设计
 
-- **封面图**：`OneClickFillDialog.vue` 调用 `/api/materials/list?id=X`，但 list 端点不识别 `id` 参数（静默忽略），导致图文物料封面错乱。改为调用新的 `GET /api/materials/{id}` 端点
-- **账号复原**：原 `handleOneClickFill` 只填 `platformConfigs`，不动 `publishAccountIds`。现在按模板 `channels` 自动勾选对应平台下所有账号
-- **表单填入**：原代码把 `record.account_configs` 当成平台嵌套 dict 处理（实际是单 detail 扁平配置），字符串字段被 `typeof === 'object'` 过滤掉，导致表单一直没填。改为按 `channels` 逐个平台应用单份配置
-- **中英文 key 不匹配**：`platformConfigs` 用英文 key（`douyin`），`channels[].platform` 是中文名（`抖音`），写入了不存在的 key。修复：加 `platformNameToKey` 映射
+- 左右分栏布局（660px）：左侧平台扁平卡片列表 + 搜索框，右侧 cookie 输入
+- 平台卡片复用 `LoginDialog` 风格（32×32 logo + 品牌色背景）
+- 支持搜索过滤（按中文名/key）、垂直滚动（自定义滚动条）
+- cookie 输入框等宽字体 + 底部 InfoFilled 提示框
+- 导入进度走 SSE 4 步流式推送（解析 → 生成文件 → 同步资料 → 创建账号）
 
-### 6. S3 视频缓存管理
+### 3. 批量检查稳定性修复（后端假死）
 
-- `_download_s3_to_cache` 在帧提取前把 S3 视频下载到 `data/s3_video_cache/`（ffmpeg 需要本地文件）
-- 308MB 起步且持续累积的运行时缓存
-- 修复：
-  - 加进 `.gitignore`（`data/s3_video_cache/`）
-  - 系统设置 → 缓存管理 → 新增"S3 视频缓存"清理项（`/api/system-info` + `/api/clear-cache` 新增 target）
+**根因**：账号管理「批量检查」复用了发布前检查弹窗 `PrePublishCheckDialog`，但该弹窗的 fixing 阶段会同时对所有失效账号自动发起 SSE 登录。并发 4 个 `checkAccount`（占满 Waitress 默认 4 线程）+ N 个 SSE `/login` 长连接（挤不进线程池）→ 后端假死（HTTP 000）。
 
-### 7. 测试改造
+**修复**：
+- **后端 Waitress 线程数 4 → 16**（`app.py`：`serve(..., threads=16)`），让并发 check + SSE login 不再互相挤占
+- **前端检查并发数 4 → 2**，降低同时拉起的 headless 浏览器数量
+- **fixing 阶段移除自动并发重登**，改为用户在失效列表里逐个点「重新登录」（不再一次弹 N 个浏览器窗口）
+- **修复检查弹窗不显示**：`PrePublishCheckDialog` 缺 `v-model` 绑定，导致 `emit('update:modelValue')` 无接收方，弹窗永远不显示
+- **新增 `mode` prop** 区分「账号检查」/「发布前检查」文案，交互逻辑完全一致
 
-- 7 个测试文件全部 TDD：写失败测试 → 改代码 → 通过
-- 修复 2 个测试文件的隔离 bug（模块级 `os.environ` 污染）
-- 修复 4 个 `_record_publish` 旧签名测试
+### 4. CSDN / 知乎资料同步改无头
 
-### 8. 杂项
+- `csdn/platform.py` + `zhihu/platform.py` 的 `sync_profile` 由 `headless=False` 改为 `headless=True`，与其它 13 个平台一致
+- 导入 cookie 时不再弹出可见浏览器窗口
 
-- 版本号 `0.5.0` → `0.6.0`（`versions` 文件）
-- 删除 `/api/image-publish/history` 端点（前端的图片历史统一走 `/api/v2/history?type=image`）
-- `start.bat` 换行符统一为 CRLF
-- 新增 `changelog/20260609.html`（v0.6.0 更新日志，7 张幻灯片）
+### 5. Dashboard 平台统计跑马灯
+
+- 参考 `DraftBox.channels` 风格，平台统计区改为横向滚动跑马灯
+- 有账号的平台高亮（品牌色），溢出时自动滚动
+- `ResizeObserver` 监听容器宽度变化，动态触发跑马灯
+
+### 6. 启动脚本强制更新
+
+- `start.sh` / `start-beta.sh` / `start.bat` / `start-beta.bat`
+- 移除「发现新版本！是否更新？[Y/n]」交互询问
+- 已有项目代码时直接 `git fetch + reset --hard origin/<branch>`
+- 无法连接 GitHub 时提示并继续使用本地版本
+- 修复 `start-beta.sh` 第 88/105 行误引 `start.sh` 的 bug
 
 ---
 
-## 文件变更统计
+## 涉及文件
 
 ```
-39 files changed, 8982 insertions(+), 1491 deletions(-)
+backend/app.py                                    | 后端假死修复(threads=16)
+backend/impl/csdn/                                | 新增 CSDN 平台实现(852 行)
+backend/impl/base_platform.py                     | cookie 导入抽象层
+backend/impl/{各平台}/platform.py                 | 15 平台接入 cookie 导入
+backend/impl/zhihu/platform.py                    | sync_profile 改无头
+backend/impl/_utils.py                            | scrape_csdn_profile
+frontend/src/components/PrePublishCheckDialog.vue | mode prop + 交互修复
+frontend/src/views/AccountManagement.vue          | 批量检查复用 + 导入弹窗
+frontend/src/views/Dashboard.vue                  | 平台统计跑马灯
+frontend/src/views/PublishCenter.vue              | 适配
+changelog/20260708.html                           | v1.2.0 更新日志
+start*.sh / start*.bat                            | 强制更新
 ```
 
-**主要文件**：
-- 后端：`init_db.py` (-76/+48)、`app.py` (-24/+83)、`blueprints/image_publish_bp.py` (-121/+91)、`blueprints/materials_bp.py` (+17)、`ext_api/__init__.py`（多处）、`ext_api/task_queue.py`、`routes/frames.py` (+26)
-- 前端：`PublishHistory.vue`（完全重写，683 行）、`PublishCenter.vue`、`ImagePublish.vue`、`OneClickFillDialog.vue`、`TaskCenter.vue`、`Settings.vue`、`platforms.js`、`useChannelForm.js`、3 个 image panel
-- 测试：7 个测试文件
-- 文档：`specs/2026-06-08-publish-history-redesign-design.md`、`plans/2026-06-08-publish-history-redesign.md`、`changelog/20260609.html`
-- 配置：`.gitignore`、`versions`、`start.bat`
+---
+
+## 验证
+
+- ✅ Cookie 导入：15 平台粘贴 cookie 字符串 → 4 步进度 → 抓到昵称头像 → 账号列表出现
+- ✅ CSDN cookie 导入：属性对齐真实文件（domain/secure/httpOnly 分布一致）
+- ✅ 批量检查：进度条正常滚动 → 失效账号显示「重新登录」按钮（不再自动弹窗）→ 后端全程响应正常
+- ✅ 发布前检查：与账号管理交互一致，文案区分显示
 
 ---
 
-## 测试
+## 不在本次范围
 
-- 后端：40/40 通过
-- 前端构建：0 error
-- 端到端 curl 冒烟：5/5 关键端点正常
-
----
-
-## 测试计划
-
-合并后人工验证：
-- [ ] PublishCenter 选 2 个账号发布一次 → DB 有 1 batch + 2 detail
-- [ ] PublishHistory 显示 1 张卡片（不是 2 张），展开后看到 2 行明细
-- [ ] ImagePublish 选 2 个图文账号发布 → DB 有 1 batch + 2 detail
-- [ ] PublishHistory `typeFilter` 切换"视频/图文/全部"过滤正常
-- [ ] 视频一键填写：封面图正常显示（`/api/materials/file/...` 走得通）
-- [ ] 图文一键填写：封面图正常显示（封面 bug 已修）
-- [ ] 一键填写选中后：账号被自动勾选 + 平台表单字段被自动填入
-- [ ] TaskCenter 显示任务列表，含 `batch_title` 列
-- [ ] 系统设置 → 缓存管理：3 项缓存都有正确的 count + size + 清理按钮
-
----
-
-## 注意事项
-
-- 已有 legacy 数据（如果有）需要走一次性迁移脚本。本分支内不做迁移（功能未正式使用 + 用户明确要求"不需要迁移历史表"）
-- `create_task` POST 端点仍写旧 `publish_tasks` 表。当前没有前端调用，TaskCenter 只用 GET；如需启用 POST 再补迁移
-- 后端 `_resolve_cover_url` 当前每个 batch 单独查 materials 表（N+1）。当前 page size ≤ 20 性能 OK，未来如需优化可批量查询
-- `cover_url` 当前返回相对路径（`/api/materials/file/...`），通过 Vite dev proxy 转发。Tauri 打包后需调整（如用绝对 URL 或相对 origin 处理）
-
----
-
-## 相关链接
-
-- **设计 spec**：`docs/superpowers/specs/2026-06-08-publish-history-redesign-design.md`
-- **实施计划**：`docs/superpowers/plans/2026-06-08-publish-history-redesign.md`
-- **更新日志**：`changelog/20260609.html`
+- 纯 `k=v` 字符串无法获取 httpOnly 的 WAF cookie（如 CSDN 的 `https_waf_cookie`），若平台强制校验 WAF 仍可能登录失败，需后续支持浏览器扩展导出完整 JSON
+- 不含数据库 schema 变更

--- a/start-beta.bat
+++ b/start-beta.bat
@@ -327,6 +327,22 @@ if "!VENV_OK!"=="0" (
     )
 )
 
+:: 检查 VC++ 运行时（greenlet/playwright 的 C 扩展依赖 MSVCP140/VCRUNTIME140）
+"%VENV_PYTHON%" -c "import greenlet" >nul 2>&1
+if !errorlevel! neq 0 (
+    echo.
+    echo   X 缺少 Microsoft Visual C++ 运行时组件
+    echo     greenlet 加载失败，浏览器自动化功能不可用
+    echo.
+    echo     请下载并安装「Visual C++ Redistributable」:
+    echo       https://aka.ms/vs/17/release/vc_redist.x64.exe
+    echo.
+    echo     安装完成后重新运行本脚本即可。
+    echo.
+    pause
+    exit /b 1
+)
+
 :: 检查 CloakBrowser 二进制文件
 set "CB_SRC=系统"
 set "CB_PATH="

--- a/start.bat
+++ b/start.bat
@@ -327,6 +327,22 @@ if "!VENV_OK!"=="0" (
     )
 )
 
+:: 检查 VC++ 运行时（greenlet/playwright 的 C 扩展依赖 MSVCP140/VCRUNTIME140）
+"%VENV_PYTHON%" -c "import greenlet" >nul 2>&1
+if !errorlevel! neq 0 (
+    echo.
+    echo   X 缺少 Microsoft Visual C++ 运行时组件
+    echo     greenlet 加载失败，浏览器自动化功能不可用
+    echo.
+    echo     请下载并安装「Visual C++ Redistributable」:
+    echo       https://aka.ms/vs/17/release/vc_redist.x64.exe
+    echo.
+    echo     安装完成后重新运行本脚本即可。
+    echo.
+    pause
+    exit /b 1
+)
+
 :: 检查 CloakBrowser 二进制文件
 set "CB_SRC=系统"
 set "CB_PATH="


### PR DESCRIPTION
- _browser.py: 有头浏览器(login_mode或headless=False)统一监听disconnected, 用户关浏览器→task.cancel(),所有平台自动生效
- app.py: postVideo捕获asyncio.CancelledError,返回友好失败信息 (CancelledError继承BaseException, except Exception捕获不到)
- PublishCenter.vue: postVideo设4小时超时,避免浏览器层提前断开导致 前端判失败但后端仍在跑
- start.bat/start-beta.bat: venv就绪后检测import greenlet,失败则提示 安装VC++ Redistributable(https://aka.ms/vs/17/release/vc_redist.x64.exe)
- 更新 pr.md