### PR TITLE
fix(login): 视频号/抖音登录稳定性优化 + 发布成功误判失败修复

### DIFF
--- a/backend/impl/_utils.py
+++ b/backend/impl/_utils.py
@@ -286,8 +286,9 @@ async def scrape_bilibili_profile(page):
 async def scrape_tencent_profile(page):
     """WeChat Channels (视频号) specific scraper.
 
-    Targets ``img.avatar`` (or ``img[alt*="头像"]``) for the avatar and
-    ``h2.finder-nickname`` for the username.
+    登录成功后创作中心首页（``/platform``）会渲染一张 ``div.finder-card``
+    资料卡，内含 ``img.avatar``（头像）和 ``h2.finder-nickname``（昵称）。
+    这里显式等待该卡片就绪后再读取，避免页面未渲染完抓不到。
 
     Returns:
         tuple[str, str]: (user_name, avatar_url)
@@ -295,14 +296,20 @@ async def scrape_tencent_profile(page):
     name = ""
     avatar = ""
     try:
-        await page.wait_for_load_state('domcontentloaded', timeout=5000)
-        await asyncio.sleep(3)
-        # Avatar: img.avatar or img[alt*="头像"]
-        avatar_el = page.locator('img.avatar, img[alt*="头像"]').first
+        await page.wait_for_load_state('domcontentloaded', timeout=10000)
+        # 显式等待 finder-card 资料卡渲染（取代固定 sleep）
+        try:
+            await page.locator('div.finder-card').first.wait_for(
+                state="visible", timeout=15000,
+            )
+        except Exception:
+            logger.info(f"[channels] finder-card 未就绪, 当前 url={page.url}")
+        # 头像: div.finder-card img.avatar
+        avatar_el = page.locator('div.finder-card img.avatar').first
         if await avatar_el.count():
             avatar = (await avatar_el.get_attribute('src') or '').strip()
-        # Username: h2.finder-nickname or class containing "nickname"
-        name_el = page.locator('h2.finder-nickname, [class*="nickname"]').first
+        # 昵称: div.finder-card h2.finder-nickname
+        name_el = page.locator('div.finder-card h2.finder-nickname').first
         if await name_el.count():
             name = (await name_el.text_content() or '').strip()
         if name:

--- a/backend/impl/channels/platform.py
+++ b/backend/impl/channels/platform.py
@@ -33,7 +33,8 @@ from ..base_platform import BasePlatform
 # Constants
 # ---------------------------------------------------------------------------
 
-TENCENT_LOGIN_URL = "https://channels.weixin.qq.com"
+TENCENT_LOGIN_URL = "https://channels.weixin.qq.com/login.html"
+TENCENT_PLATFORM_URL = "https://channels.weixin.qq.com/platform"
 TENCENT_UPLOAD_URL = "https://channels.weixin.qq.com/platform/post/create"
 TENCENT_MANAGE_URL = "https://channels.weixin.qq.com/platform/post/list"
 
@@ -61,161 +62,15 @@ def _format_short_title(origin_title: str) -> str:
     return formatted_string
 
 
-# ---------------------------------------------------------------------------
-# QR-code extraction helpers
-# ---------------------------------------------------------------------------
-
-async def _extract_qrcode_src(page) -> str:
-    """Extract the QR code image ``src`` from the Channels login page.
-
-    The QR code lives inside an iframe (``login-for-iframe``) on the
-    Channels login page.  Falls back to top-level selectors when the
-    iframe is unavailable.
-    """
-    # Primary: iframe approach
-    try:
-        iframe_locator = page.frame_locator('[src*="login-for-iframe"]')
-        qr_code_img = iframe_locator.locator("div#app img.qrcode").first
-        await qr_code_img.wait_for(state="visible", timeout=30000)
-        src = await qr_code_img.get_attribute("src")
-        if src and src.startswith("data:image/"):
-            return src
-    except Exception:
-        pass
-
-    # Fallback: top-level selectors
-    for selector in (
-        "div.login-qrcode-wrap img.qrcode",
-        "div.qrcode-wrap img.qrcode",
-        "img.qrcode",
-        'img[src^="data:image/"]',
-    ):
-        qr_code_img = page.locator(selector).first
-        try:
-            if not await qr_code_img.count() or not await qr_code_img.is_visible():
-                continue
-            src = await qr_code_img.get_attribute("src")
-            if src and src.startswith("data:image/"):
-                return src
-        except Exception:
-            continue
-
-    raise RuntimeError("未获取到视频号登录二维码地址")
-
-
-async def _is_qrcode_expired(page) -> bool:
-    """Check whether the displayed QR code has expired."""
-    for selector in (
-        'div.mask.show p.refresh-tip:has-text("二维码已过期，点击刷新")',
-        'div.mask.show p.refresh-tip:has-text("网络不可用，点击刷新")',
-        'p.refresh-tip:has-text("二维码已过期，点击刷新")',
-        'p.refresh-tip:has-text("网络不可用，点击刷新")',
-    ):
-        tip = page.locator(selector).first
-        try:
-            if await tip.count() and await tip.is_visible():
-                return True
-        except Exception:
-            continue
-    return False
-
-
-async def _is_qrcode_scanned(page) -> bool:
-    """Check whether the user has scanned the QR code."""
-    for selector in (
-        'div.qr-tip div:has-text("已扫码")',
-        'div.qr-tip div:has-text("需在手机上进行确认")',
-    ):
-        tip = page.locator(selector).first
-        try:
-            if await tip.count() and await tip.is_visible():
-                return True
-        except Exception:
-            continue
-    return False
-
-
-async def _refresh_qrcode(page) -> None:
-    """Click the refresh area to regenerate an expired QR code."""
-    # Try visible refresh-wrap first
-    for selector in (
-        "div.login-qrcode-wrap div.mask.show div.refresh-wrap",
-        "div.login-qrcode-wrap div.mask.show .refresh-wrap",
-    ):
-        refresh_wrap = page.locator(selector).first
-        try:
-            if not await refresh_wrap.count() or not await refresh_wrap.is_visible():
-                continue
-            await refresh_wrap.click()
-            return
-        except Exception:
-            continue
-
-    # Try tip-based refresh
-    for selector in (
-        'div.mask.show p.refresh-tip:has-text("二维码已过期，点击刷新")',
-        'div.mask.show p.refresh-tip:has-text("网络不可用，点击刷新")',
-        'p.refresh-tip:has-text("二维码已过期，点击刷新")',
-        'p.refresh-tip:has-text("网络不可用，点击刷新")',
-    ):
-        tip = page.locator(selector).first
-        try:
-            if not await tip.count() or not await tip.is_visible():
-                continue
-            refresh_wrap = tip.locator(
-                "xpath=ancestor::div[contains(@class, 'refresh-wrap')]"
-            ).first
-            if await refresh_wrap.count():
-                await refresh_wrap.click()
-            else:
-                await tip.click()
-            return
-        except Exception:
-            continue
-
-    # Final fallback
-    fallback = page.locator("div.login-qrcode-wrap div.refresh-wrap").first
-    if await fallback.count():
-        await fallback.click()
-        return
-
-    raise RuntimeError("未找到可点击的视频号二维码刷新区域")
-
-
 async def _is_login_completed(page) -> bool:
-    """Detect whether the user has completed the QR-code login flow."""
-    publish_markers = [
-        page.locator('div:has-text("发表视频")').first,
-        page.locator('button:has-text("发表")').first,
-        page.locator('button:has-text("保存草稿")').first,
-    ]
-    for marker in publish_markers:
-        try:
-            if await marker.count() and await marker.is_visible():
-                return True
-        except Exception:
-            continue
+    """Detect whether the user has completed the QR-code login flow.
 
-    if not (
-        page.url.startswith(TENCENT_UPLOAD_URL)
-        or page.url.startswith(TENCENT_MANAGE_URL)
-    ):
-        return False
-
-    login_markers = [
-        page.locator("div.login-qrcode-wrap").first,
-        page.locator("div.qrcode-wrap").first,
-        page.locator("img.qrcode").first,
-        page.locator('span:has-text("微信扫码登录 视频号助手")').first,
-    ]
-    for marker in login_markers:
-        try:
-            if await marker.count() and await marker.is_visible():
-                return False
-        except Exception:
-            continue
-
-    return True
+    登录成功后页面会从 ``/login.html`` 跳转到 ``/platform/*``（创作中心首页
+    或其子页）。这里只看 URL：进入 ``/platform`` 且不在 ``/login`` 即视为
+    登录完成。不依赖宽泛文本匹配，避免登录页文案误判。
+    """
+    url = page.url
+    return "/platform" in url and "/login" not in url
 
 
 # ---------------------------------------------------------------------------
@@ -881,11 +736,12 @@ class ChannelsPlatform(BasePlatform):
     # ------------------------------------------------------------------
 
     async def login(self, id: str, status_queue: Queue, account_id=None) -> None:
-        """Perform Channels (视频号) login via QR code scan.
+        """Perform Channels (视频号) login.
 
-        Opens ``https://channels.weixin.qq.com``, extracts the QR code
-        from the login iframe, polls for scan/expiry, and completes the
-        post-login flow via ``save_login_result``.
+        直接打开登录页 ``/login.html``，由用户在浏览器里扫码完成登录。
+        后端只负责轮询 URL：一旦从登录页跳到 ``/platform/*``，即判定登录成功，
+        随后导航到创作中心首页抓取头像/昵称并落库。
+        不再提取/推送二维码——前端只等 ``status:200``。
         """
         browser = await self.create_browser(login_mode=True)
         success = False
@@ -894,22 +750,20 @@ class ChannelsPlatform(BasePlatform):
             page = await context.new_page()
 
             await page.goto(TENCENT_LOGIN_URL)
+            logger.info("[发布] 登录页已打开，等待用户扫码")
 
-            # Extract QR code and push to frontend
-            qrcode_src = await _extract_qrcode_src(page)
-            status_queue.put(json.dumps({
-                "status": "qrcode",
-                "qrcode": qrcode_src,
-            }))
-            logger.info("[发布] QR code ready, waiting for scan")
-
-            # Poll for login completion（无限等，浏览器由用户自己关）
+            # 轮询 URL 判断登录完成（无限等，浏览器由用户自己关）
             poll_interval = 3
-            scanned_logged = False
             while True:
                 if await _is_login_completed(page):
                     logger.info(f"[发布] login successful, redirected to: {page.url}")
-                    await asyncio.sleep(2)
+                    # 资料卡 (finder-card) 在创作中心首页 /platform 渲染。
+                    # 若登录后落在子页（如 /platform/post/create），导航到首页再抓。
+                    if not page.url.rstrip("/").endswith("channels.weixin.qq.com/platform"):
+                        try:
+                            await page.goto(TENCENT_PLATFORM_URL, timeout=15000)
+                        except Exception as nav_e:
+                            logger.info(f"[发布] 导航到创作中心首页失败(继续尝试抓取): {nav_e}")
                     await save_login_result(
                         context,
                         page,
@@ -921,23 +775,6 @@ class ChannelsPlatform(BasePlatform):
                     )
                     success = True
                     return
-
-                if not scanned_logged and await _is_qrcode_scanned(page):
-                    logger.info("[发布] QR code scanned, awaiting confirmation")
-                    scanned_logged = True
-
-                if await _is_qrcode_expired(page):
-                    logger.info("[发布] QR code expired, refreshing")
-                    await _refresh_qrcode(page)
-                    await asyncio.sleep(1)
-                    try:
-                        qrcode_src = await _extract_qrcode_src(page)
-                        status_queue.put(json.dumps({
-                            "status": "qrcode",
-                            "qrcode": qrcode_src,
-                        }))
-                    except Exception:
-                        pass
 
                 await asyncio.sleep(poll_interval)
         except Exception as exc:
@@ -1037,7 +874,7 @@ class ChannelsPlatform(BasePlatform):
         try:
             context = await self.create_context(browser, storage_state=cookie_path)
             page = await context.new_page()
-            await page.goto(TENCENT_UPLOAD_URL)
+            await page.goto(TENCENT_PLATFORM_URL)
             name, avatar = await scrape_tencent_profile(page)
             await page.close()
             await context.close()

--- a/backend/impl/douyin/platform.py
+++ b/backend/impl/douyin/platform.py
@@ -84,13 +84,12 @@ class DouyinPlatform(BasePlatform):
     # ------------------------------------------------------------------
 
     async def login(self, id: str, status_queue: Queue, account_id=None) -> None:
-        """Perform Douyin login via QR code scan.
+        """Perform Douyin login.
 
-        Opens ``https://creator.douyin.com/``, extracts the QR image from
-        ``get_by_role("img", name="二维码")``, sends the image URL to
-        *status_queue*, then waits for the page to navigate away (indicating
-        the user scanned the code).  On success, scrapes the user profile and
-        saves the login result.
+        直接打开 ``https://creator.douyin.com/``，由用户在浏览器里扫码完成
+        登录。后端通过监听主框架 URL 变化判断登录成功（不设超时，浏览器由
+        用户自己关），随后抓取用户资料并落库。不再提取/推送二维码——前端
+        只等 ``status:200``。
         """
         url_changed_event = asyncio.Event()
 
@@ -106,12 +105,6 @@ class DouyinPlatform(BasePlatform):
                 page = await context.new_page()
                 await page.goto("https://creator.douyin.com/")
                 original_url = page.url
-
-                # Extract QR code image
-                img_locator = page.get_by_role("img", name="二维码")
-                src = await img_locator.get_attribute("src")
-                logger.info("QR image src: %s", src)
-                status_queue.put(src)
 
                 # Monitor URL change via framenavigated
                 page.on(


### PR DESCRIPTION
视频号(channels):
- login 去掉二维码提取/刷新逻辑(_extract_qrcode_src 等 4 个函数) 前端已是"打开登录页自己扫"模式, 不消费后端推送的二维码; 二维码提取的 30s 超时是登录页停留被自动关闭的元凶
- 改为打开 /login.html + 轮询 URL 判断成功(跳到 /platform/* 即成功)
- _is_login_completed 改为纯 URL 判断, 去掉 has-text 误判
- scrape_tencent_profile 用 wait_for(finder-card) 取代固定 sleep
- 登录成功后确保在 /platform/ 首页再抓资料卡

抖音(douyin):
- login 去掉 get_by_role(二维码).get_attribute + put(src) 多余逻辑 改为纯 URL 变化监听(url_changed_event, 无超时)

_browser.py:
- 包装 browser.close + disarm 标志, 发布成功后收尾关浏览器不再误判为失败 (用户手动关浏览器仍正常判失败)