### PR TITLE
fix(theme): 亮色主题多处样式适配 + 标签弹窗中文输入修复

### DIFF
--- a/frontend/src/components/BatchTagDialog.vue
+++ b/frontend/src/components/BatchTagDialog.vue
@@ -272,7 +272,7 @@ watch(() => props.modelValue, (v) => {
   .batch-section {
     display: flex;
     flex-direction: column;
-    background: rgba(0, 0, 0, 0.25);
+    background: $bg-surface;
     border: 1px solid $border;
     border-radius: $radius-card;
     overflow: hidden;

--- a/frontend/src/components/TagPopover.vue
+++ b/frontend/src/components/TagPopover.vue
@@ -3,7 +3,7 @@
     :visible="visible"
     placement="bottom"
     :width="240"
-    @update:visible="$emit('update:visible', $event)"
+    @update:visible="onVisibleUpdate"
   >
     <template #reference>
       <slot />
@@ -15,6 +15,8 @@
           size="small"
           placeholder="搜索或创建标签..."
           clearable
+          @compositionstart="composing = true"
+          @compositionend="composing = false"
           @keyup.enter="handleCreate"
         />
       </div>
@@ -57,6 +59,13 @@ const emit = defineEmits(['update:visible', 'changed'])
 
 const accountStore = useAccountStore()
 const keyword = ref('')
+// IME 组合输入中（如中文选词期间）。为 true 时屏蔽 popover 的关闭，避免候选词点击误触发 update:visible(false)
+const composing = ref(false)
+
+function onVisibleUpdate(val) {
+  if (!val && composing.value) return
+  emit('update:visible', val)
+}
 
 const filteredTags = computed(() => {
   if (!keyword.value) return accountStore.allTags

--- a/frontend/src/views/AccountManagement.vue
+++ b/frontend/src/views/AccountManagement.vue
@@ -1079,7 +1079,7 @@ const submitAccountForm = () => {
       color: $text-primary;
       margin: 0;
       letter-spacing: -0.5px;
-      background: linear-gradient(135deg, #fff 0%, #a5b4fc 100%);
+      background: $gradient-brand;
       -webkit-background-clip: text;
       -webkit-text-fill-color: transparent;
       background-clip: text;
@@ -1153,7 +1153,8 @@ const submitAccountForm = () => {
       &.active {
         background: rgba($brand-start, 0.15);
         border-color: $brand-start;
-        color: #fff;
+        color: $brand-start;
+        font-weight: 600;
         box-shadow: 0 0 20px rgba($brand-start, 0.2);
       }
 


### PR DESCRIPTION
- BatchTagDialog: 账号/标签区背景 rgba(0,0,0,0.25) 改为主题变量 $bg-surface，亮色下不再发灰
- AccountManagement: 标题渐变改用 $gradient-brand，全站统一；筛选按钮选中态文字由写死 #fff 改为 $brand-start，亮色下清晰可辨
- TagPopover: IME 组合输入期间屏蔽 popover 关闭，修复中文选词导致弹层消失