### PR TITLE
fix(baijiahao): check_cookie 增加 passport 失效跳转与业务域兜底识别

### DIFF
--- a/backend/impl/baijiahao/platform.py
+++ b/backend/impl/baijiahao/platform.py
@@ -42,6 +42,16 @@ class BaijiahaoPlatform(BasePlatform):
     # baijiahao.baidu.com / passport.baidu.com / www.baidu.com 都生效。
     platform_cookie_domain = ".baidu.com"
 
+    # Cookie 失效时可能跳到的所有百度账号体系登录/中间页子串。
+    # 任一命中即视为失效,不再依赖单一精确业务登录 URL。
+    _COOKIE_INVALID_URL_MARKERS = (
+        "/builder/theme/bjh/login",
+        "passport.baidu.com/v3/login",
+        "passport.baidu.com/v3/ucenter",
+        "wappass.baidu.com",
+        "auth.baidu.com",
+    )
+
     def _parse_cookie_to_storage_state(
         self, cookie_str: str
     ) -> tuple[list[dict], list[dict]]:
@@ -133,10 +143,15 @@ class BaijiahaoPlatform(BasePlatform):
         """Return True if the saved cookie file is still valid.
 
         Opens ``https://baijiahao.baidu.com/builder/rc/home`` with the
-        stored cookies.  If redirected to the login page, the cookie
-        is considered invalid.
+        stored cookies.  Cookie invalid if:
+        - cookie 文件不存在
+        - 跳到任意失效 URL marker (见 ``_COOKIE_INVALID_URL_MARKERS``)
+        - 跳出了 baijiahao.baidu.com 业务域 (兜底)
         """
         cookie_path = str(Path(BASE_DIR / "cookiesFile" / cookie_file))
+        if not os.path.exists(cookie_path):
+            logger.info("[baijiahao] cookie file not found")
+            return False
         browser = await self.create_browser(headless=True)
         try:
             context = await self.create_context(
@@ -150,12 +165,27 @@ class BaijiahaoPlatform(BasePlatform):
                 await page.wait_for_load_state("domcontentloaded", timeout=10000)
                 await asyncio.sleep(2)
 
-                if "baijiahao.baidu.com/builder/theme/bjh/login" in page.url:
-                    logger.info("[baijiahao] cookie expired, needs re-login")
+                current_url = page.url or ""
+                # 黑名单: 任一失效 marker 命中即视为失效
+                for marker in self._COOKIE_INVALID_URL_MARKERS:
+                    if marker in current_url:
+                        logger.info(
+                            f"[baijiahao] cookie expired (matched: {marker})"
+                        )
+                        return False
+                # 业务域兜底: URL 必须在 baijiahao.baidu.com 下才算成功
+                if not current_url.startswith(
+                    "https://baijiahao.baidu.com/"
+                ):
+                    logger.info(
+                        f"[baijiahao] cookie redirected off-domain: {current_url}"
+                    )
                     return False
-                else:
-                    logger.info("[baijiahao] cookie valid")
-                    return True
+                logger.info("[baijiahao] cookie valid")
+                return True
+            except Exception as exc:
+                logger.info(f"[baijiahao] cookie check error: {exc}")
+                return False
             finally:
                 await context.close()
         finally:


### PR DESCRIPTION
原 check_cookie 唯一失效条件是 URL 含 baijiahao.baidu.com/builder/theme/bjh/login。 但 cookie 失效时百度账号体系常常跳到 passport.baidu.com/v3/login、 /v3/ucenter、wappass.baidu.com、auth.baidu.com 等登录/中间页， 原判断会一律判 True 误报成功。

修复:
- 新增类常量 _COOKIE_INVALID_URL_MARKERS,纳入 5 个失效 marker
- 增加业务域白名单兜底:URL 不在 https://baijiahao.baidu.com/ 下也算失效
- cookie 文件不存在直接返回 False,避免无意义开浏览器
- 整体 try/except 转 False,异常不再向外抛出 (与 bilibili/xhs/youtube 一致)