### PR TITLE
fix(weibo): 封面优先用 16:9/9:16 + 内容声明版本2选项点击健壮性

### DIFF
--- a/backend/impl/weibo/platform.py
+++ b/backend/impl/weibo/platform.py
@@ -812,6 +812,9 @@ class WeiboPlatform(BasePlatform):
         account_file = kwargs.get("account_file", []) or []
         thumbnail_landscape_path = kwargs.get("thumbnail_landscape_path")
         thumbnail_portrait_path = kwargs.get("thumbnail_portrait_path")
+        # 16:9 / 9:16 封面(微博封面框实际比例,优先于 4:3 / 3:4 使用)
+        thumbnail_landscape_169_path = kwargs.get("thumbnail_landscape_169_path")
+        thumbnail_portrait_916_path = kwargs.get("thumbnail_portrait_916_path")
         desc = kwargs.get("desc", "") or ""
         category = kwargs.get("category")
         ai_content = kwargs.get("ai_content", "") or ""
@@ -858,6 +861,8 @@ class WeiboPlatform(BasePlatform):
                         account_file=cookie_path,
                         thumbnail_landscape_path=thumbnail_landscape_path,
                         thumbnail_portrait_path=thumbnail_portrait_path,
+                        thumbnail_landscape_169_path=thumbnail_landscape_169_path,
+                        thumbnail_portrait_916_path=thumbnail_portrait_916_path,
                         desc=desc,
                         category=category,
                         ai_content=ai_content,
@@ -883,6 +888,8 @@ class WeiboPlatform(BasePlatform):
         account_file: str,
         thumbnail_landscape_path=None,
         thumbnail_portrait_path=None,
+        thumbnail_landscape_169_path=None,
+        thumbnail_portrait_916_path=None,
         desc="",
         category=None,
         ai_content="",
@@ -972,6 +979,8 @@ class WeiboPlatform(BasePlatform):
                     page,
                     thumbnail_landscape_path,
                     thumbnail_portrait_path,
+                    thumbnail_landscape_169_path,
+                    thumbnail_portrait_916_path,
                 )
                 logger.info("[设置封面] 封面设置完成")
 
@@ -1483,6 +1492,8 @@ class WeiboPlatform(BasePlatform):
         page,
         thumbnail_landscape_path=None,
         thumbnail_portrait_path=None,
+        thumbnail_landscape_169_path=None,
+        thumbnail_portrait_916_path=None,
     ):
         """上传封面。
 
@@ -1494,11 +1505,15 @@ class WeiboPlatform(BasePlatform):
         4. 等待「编辑封面」弹层出现
         5. 找到弹层内的隐藏 ``input[type=file]`` 上传图片
         6. 点击「完成」按钮
+
+        封面尺寸优先级:微博封面框实际是 16:9 / 9:16,优先用
+        ``thumbnail_landscape_169_path``(16:9) / ``thumbnail_portrait_916_path``
+        (9:16);没有时回退到 4:3 / 3:4。
         """
         cover_path = await WeiboPlatform._pick_cover_by_aspect(
             page,
-            landscape_path=thumbnail_landscape_path,
-            portrait_path=thumbnail_portrait_path,
+            landscape_path=thumbnail_landscape_169_path or thumbnail_landscape_path,
+            portrait_path=thumbnail_portrait_916_path or thumbnail_portrait_path,
         )
         if not cover_path or not os.path.exists(cover_path):
             logger.info("[发布] 无封面文件,跳过封面上传")
@@ -1908,44 +1923,45 @@ class WeiboPlatform(BasePlatform):
             return
 
         await trigger.click(force=True)
-        await asyncio.sleep(0.5)
+        # 面板展开是动画,实测 0.5s 偶尔不够,给 1s 让 _panel 完整渲染
+        await asyncio.sleep(1)
 
-        # 选必选项
-        try:
-            required_btn = page.get_by_role("button", name=required_text, exact=True).first
-            await required_btn.wait_for(state="visible", timeout=5000)
-            await required_btn.click()
-            logger.info("[发布] 已选内容声明(版本2必选): %s", required_text)
-            await asyncio.sleep(0.3)
-        except Exception as e:
-            logger.warning("[发布] 选择内容声明(版本2必选 %s)失败: %s", required_text, e)
+        # 通用:在弹出面板里点某个选项 button(用 force 跳过 intercept)
+        async def _click_option(text, timeout=5000):
+            """点面板里的选项 button,返回是否成功。"""
+            btn = page.get_by_role("button", name=text, exact=True).first
+            try:
+                await btn.wait_for(state="visible", timeout=timeout)
+                # woo-pop 弹层选项同样会被判 intercept,必须 force=True
+                await btn.click(force=True)
+                return True
+            except Exception as e:
+                logger.warning("[发布] 内容声明(版本2)点击选项「%s」失败: %s", text, e)
+                return False
+
+        # 选必选项(必选区必须选一个,失败则 ESC 退出)
+        ok = await _click_option(required_text, timeout=5000)
+        if not ok:
+            logger.warning("[发布] 内容声明(版本2)必选项「%s」选择失败,放弃", required_text)
             await page.keyboard.press("Escape")
             await asyncio.sleep(0.3)
             return
+        logger.info("[发布] 已选内容声明(版本2必选): %s", required_text)
+        await asyncio.sleep(0.4)
 
-        # 选可选项(可选,空则跳过)
+        # 选可选项(可选,空则跳过;失败不中断,继续点确定)
         if optional_stmt and optional_stmt.strip():
-            try:
-                optional_btn = page.get_by_role(
-                    "button", name=optional_stmt.strip(), exact=True
-                ).first
-                await optional_btn.wait_for(state="visible", timeout=3000)
-                await optional_btn.click()
-                logger.info("[发布] 已选内容声明(版本2可选): %s", optional_stmt.strip())
-                await asyncio.sleep(0.3)
-            except Exception as e:
-                logger.warning(
-                    "[发布] 选择内容声明(版本2可选 %s)失败: %s",
-                    optional_stmt.strip(), e,
-                )
-                # 可选失败不中断,继续点确定
+            opt_text = optional_stmt.strip()
+            if await _click_option(opt_text, timeout=3000):
+                logger.info("[发布] 已选内容声明(版本2可选): %s", opt_text)
+                await asyncio.sleep(0.4)
 
-        # 点「确定」按钮提交选择
+        # 点「确定」按钮提交选择(必点,否则选择不生效)
         try:
             confirm_btn = page.get_by_role("button", name="确定", exact=True).first
             await confirm_btn.wait_for(state="visible", timeout=3000)
-            await confirm_btn.click()
-            logger.info("[发布] 内容声明(版本2)已确定")
+            await confirm_btn.click(force=True)
+            logger.info("[发布] 内容声明(版本2)已点确定,选择提交")
             await asyncio.sleep(0.5)
         except Exception as e:
             logger.warning("[发布] 点内容声明(版本2)确定按钮失败: %s", e)


### PR DESCRIPTION
1. 封面尺寸:app.py 已透传 thumbnail_landscape_169/thumbnail_portrait_916, 但微博 _upload_all/_upload_one_video 只读了 4:3/3:4,导致 16:9/9:16 被丢弃。 现全链路透传,_set_cover 优先用 16:9(横版)/9:16(竖版),无则回退 4:3/3:4。

2. 内容声明版本2:选项点击未加 force,被 woo-pop 弹层 intercept 拦截, 导致点开了下拉但没选上、也没点确定。现 _click_option 统一 force=True, 面板展开等待增至 1s,必选失败 ESC 退出,确定按钮也 force 点击。