### PR TITLE
feat(weixin_gzh): 完成微信公众号视频发布全流程(含定时发布时分选择)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -150,6 +150,10 @@ from blueprints.channels_bp import channels_bp  # noqa: E402
 app.register_blueprint(channels_bp)
 logger.info("[Startup] channels_bp registered OK")
 
+from blueprints.weixin_gzh_bp import weixin_gzh_bp  # noqa: E402
+app.register_blueprint(weixin_gzh_bp)
+logger.info("[Startup] weixin_gzh_bp registered OK")
+
 from blueprints.materials_bp import materials_bp  # noqa: E402
 app.register_blueprint(materials_bp)
 logger.info("[Startup] materials_bp registered OK")
@@ -1046,6 +1050,10 @@ def postVideo():
                 vivo_declaration=data.get('vivoDeclaration', ''),
                 vivo_privacy=data.get('vivoPrivacy', '公开'),
                 vivo_download_permission=data.get('vivoDownloadPermission', '允许'),
+                # 微信公众号特有参数
+                is_original=data.get('isOriginal', False),
+                gzh_collection_name=data.get('gzhCollectionName', ''),
+                gzh_claim_source=data.get('gzhClaimSource', ''),
             ))
         else:
             result = publish_fn(
@@ -1131,6 +1139,10 @@ def postVideo():
                 vivo_declaration=data.get('vivoDeclaration', ''),
                 vivo_privacy=data.get('vivoPrivacy', '公开'),
                 vivo_download_permission=data.get('vivoDownloadPermission', '允许'),
+                # 微信公众号特有参数
+                is_original=data.get('isOriginal', False),
+                gzh_collection_name=data.get('gzhCollectionName', ''),
+                gzh_claim_source=data.get('gzhClaimSource', ''),
             )
         if result:
             return jsonify({"code": 200, "msg": "发布任务已提交", "data": None}), 200
@@ -1213,6 +1225,10 @@ def postVideoBatch():
                     is_draft=data.get('isDraft', False),
                     audience=data.get('audience', 'not_kids'),
                     altered_content=data.get('alteredContent', False),
+                    # 微信公众号特有参数
+                    is_original=data.get('isOriginal', False),
+                    gzh_collection_name=data.get('gzhCollectionName', ''),
+                    gzh_claim_source=data.get('gzhClaimSource', ''),
                 ))
             else:
                 result = publish_fn(
@@ -1242,6 +1258,10 @@ def postVideoBatch():
                     is_draft=data.get('isDraft', False),
                     audience=data.get('audience', 'not_kids'),
                     altered_content=data.get('alteredContent', False),
+                    # 微信公众号特有参数
+                    is_original=data.get('isOriginal', False),
+                    gzh_collection_name=data.get('gzhCollectionName', ''),
+                    gzh_claim_source=data.get('gzhClaimSource', ''),
                 )
             if not result:
                 failures.append({"index": idx, "reason": "发布失败：页面未跳转"})

--- a/backend/blueprints/weixin_gzh_bp.py
+++ b/backend/blueprints/weixin_gzh_bp.py
@@ -1,0 +1,212 @@
+"""微信公众号创作者平台相关 API 代理。
+
+用 CloakBrowser 打开公众号合集管理页(appmsgalbummgr) →
+点「视频合集」tab → 解析表格 .album-title 文本(合集名) →
+返回给前端下拉选项。
+
+公众号特殊性: 所有功能 URL 必须带 token(每次会话变化),
+因此先访问 https://mp.weixin.qq.com/ 让 cookie 触发跳转,
+再从 URL 解析 token 拼装合集管理页 URL。
+"""
+
+import asyncio
+import re
+import sqlite3
+from pathlib import Path
+
+from flask import Blueprint, request, jsonify
+
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from conf import BASE_DIR
+from util._logger import get_channel_logger
+from impl._browser import create_browser, create_context
+
+logger = get_channel_logger("weixin_gzh")
+
+weixin_gzh_bp = Blueprint('weixin_gzh', __name__, url_prefix='/api/weixin_gzh')
+
+# 公众号首页入口(不带 token,访问后由 cookie 触发自动跳转到带 token 的 home)
+_LOGIN_URL = "https://mp.weixin.qq.com/"
+_TOKEN_RE = re.compile(r"[?&]token=(\d+)")
+# 合集管理页(token 由 _resolve_token 拼装,type=5 为视频合集)
+_ALBUM_MGR_PATH = (
+    "https://mp.weixin.qq.com/cgi-bin/appmsgalbummgr"
+    "?action=list&token={token}&lang=zh_CN&type=5"
+)
+
+
+def _get_cookie_path(cookie_file: str) -> str:
+    return str(Path(BASE_DIR / "cookiesFile" / cookie_file))
+
+
+def _get_account_cookie_file(account_id: str) -> str | None:
+    conn = sqlite3.connect(str(Path(BASE_DIR / "db" / "database.db")))
+    cursor = conn.cursor()
+    if account_id:
+        cursor.execute("SELECT filePath FROM user_info WHERE id = ?", (account_id,))
+    else:
+        # type=17 为微信公众号
+        cursor.execute("SELECT filePath FROM user_info WHERE type = 17 LIMIT 1")
+    row = cursor.fetchone()
+    conn.close()
+    if not row:
+        return None
+    return row[0]
+
+
+def run_async(coro):
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            import threading
+            result = {}
+
+            def _run():
+                new_loop = asyncio.new_event_loop()
+                try:
+                    result["v"] = new_loop.run_until_complete(coro)
+                finally:
+                    new_loop.close()
+
+            t = threading.Thread(target=_run)
+            t.start()
+            t.join()
+            return result.get("v")
+    except RuntimeError:
+        pass
+    return asyncio.run(coro)
+
+
+@weixin_gzh_bp.route('/collections', methods=['GET'])
+def list_collections():
+    """获取账号的视频合集列表。
+
+    Query params:
+        account_id: 账号 id(用于取 cookie)
+
+    流程:
+        1. 用账号 cookie 打开公众号首页,等 cookie 触发跳转,解析 token
+        2. 用 token 打开合集管理页(appmsgalbummgr)
+        3. 点「视频合集」tab
+        4. 解析表格 tbody tr 的 .album-title 文本(合集名)
+
+    Returns:
+        {"code": 200, "data": {"list": [{"name": "..."}], "total": N}}
+    """
+    account_id = request.args.get('account_id')
+    logger.info(f"[合集列表] 收到请求: account_id={account_id}")
+
+    try:
+        cookie_file = _get_account_cookie_file(account_id)
+        if not cookie_file:
+            logger.warning(f"[合集列表] 账号不存在: {account_id}")
+            return jsonify({"code": 404, "msg": "没有可用的微信公众号账号"}), 404
+
+        result = run_async(_fetch_collections_via_browser(cookie_file))
+
+        if result.get("success"):
+            data = result.get("data", {})
+            logger.info(f"[合集列表] 成功,共 {data.get('total', 0)} 个合集")
+            return jsonify({"code": 200, "data": data})
+        else:
+            logger.error(f"[合集列表] 失败: {result.get('error')}")
+            return jsonify({
+                "code": 500, "msg": result.get("error", "请求失败"),
+            }), 500
+    except Exception as e:
+        logger.error(f"[合集列表] 异常: {e}", exc_info=True)
+        return jsonify({"code": 500, "msg": str(e)}), 500
+
+
+async def _fetch_collections_via_browser(cookie_file: str) -> dict:
+    """打开公众号合集管理页,点「视频合集」tab,解析表格 DOM 拿合集列表。
+
+    DOM 结构(需求文档):
+      tab: <li class="weui-desktop-tag">视频合集</li>
+      表格: table.weui-desktop-table > tbody > tr > td.album-title
+        合集名在 .album-title-tips 文本里
+
+    全程文案/结构语义定位,禁用 data-v 随机串。
+    """
+    cookie_path = _get_cookie_path(cookie_file)
+
+    browser = await create_browser(headless=True)
+    try:
+        context = await create_context(browser, storage_state=cookie_path)
+        try:
+            page = await context.new_page()
+
+            # 1. 访问公众号首页,等 cookie 触发跳转,解析 token
+            logger.info("[合集列表] 打开公众号首页,解析 token...")
+            try:
+                await page.goto(_LOGIN_URL, wait_until="domcontentloaded", timeout=30000)
+            except Exception as e:
+                logger.info(f"[合集列表] 首页加载(非致命): {e}")
+
+            token = ""
+            deadline = asyncio.get_event_loop().time() + 15
+            while asyncio.get_event_loop().time() < deadline:
+                m = _TOKEN_RE.search(page.url or "")
+                if m:
+                    token = m.group(1)
+                    break
+                await asyncio.sleep(0.5)
+            if not token:
+                return {"success": False, "error": f"未能解析 token(cookie 可能失效), URL={page.url}"}
+            logger.info(f"[合集列表] 获取到 token: {token}")
+
+            # 2. 打开合集管理页
+            album_url = _ALBUM_MGR_PATH.format(token=token)
+            logger.info(f"[合集列表] 打开合集管理页...")
+            try:
+                await page.goto(album_url, wait_until="domcontentloaded", timeout=30000)
+                await asyncio.sleep(3)
+            except Exception as e:
+                logger.info(f"[合集列表] 合集页加载(非致命): {e}")
+
+            # 3. 点「视频合集」tab
+            tag = page.locator("li.weui-desktop-tag", has_text="视频合集").first
+            try:
+                await tag.wait_for(state="visible", timeout=10000)
+                await tag.click()
+                logger.info("[合集列表] 已点击「视频合集」tab")
+            except Exception as e:
+                logger.info(f"[合集列表] 未找到「视频合集」tab(可能默认已选中): {e}")
+            await asyncio.sleep(1.5)
+
+            # 4. 解析表格 tbody tr 的 .album-title 文本
+            title_els = page.locator("table.weui-desktop-table tbody tr .album-title")
+            ready = False
+            for _ in range(20):
+                if await title_els.count() > 0:
+                    ready = True
+                    break
+                await asyncio.sleep(0.5)
+            if not ready:
+                # 没有合集也是正常情况
+                logger.info("[合集列表] 表格中未发现合集(账号可能无合集)")
+                return {"success": True, "data": {"list": [], "total": 0}}
+
+            count = await title_els.count()
+            logger.info(f"[合集列表] 发现 {count} 个合集,开始解析")
+            items = []
+            for i in range(count):
+                try:
+                    # 合集名在 .album-title-tips 文本里
+                    tips = title_els.nth(i).locator(".album-title-tips").first
+                    if await tips.count():
+                        name = (await tips.inner_text()).strip()
+                    else:
+                        name = (await title_els.nth(i).inner_text()).strip()
+                    if name:
+                        items.append({"name": name})
+                except Exception as e:
+                    logger.info(f"[合集列表] 第 {i} 项解析失败: {e}")
+
+            logger.info(f"[合集列表] 解析完成,共 {len(items)} 个合集")
+            return {"success": True, "data": {"list": items, "total": len(items)}}
+        finally:
+            await context.close()
+    finally:
+        await browser.close()

--- a/backend/impl/weixin_gzh/platform.py
+++ b/backend/impl/weixin_gzh/platform.py
@@ -16,18 +16,22 @@
 
 import asyncio
 import json
+import os
 import re
 import threading
 import time
 from pathlib import Path
 from queue import Queue
 
-from util._logger import get_channel_logger
+from util._logger import bind_account_name, get_channel_logger
 
 from conf import BASE_DIR
 
 from .._browser import create_browser_sync, create_context_sync
 from .._utils import (
+    clear_input,
+    get_account_name_by_cookie_file,
+    parse_schedule_time,
     save_login_result,
     scrape_weixin_gzh_profile,
 )
@@ -39,6 +43,30 @@ logger = get_channel_logger("weixin_gzh")
 _LOGIN_URL = "https://mp.weixin.qq.com/"
 _HOME_PATH = "/cgi-bin/home"
 _TOKEN_RE = re.compile(r"[?&]token=(\d+)")
+
+# 素材上传页（token 由 _resolve_token 拼装）。
+# 对应文档：cgi-bin/appmsg?t=media/videomsg_edit&action=video_edit&type=15&isNew=1
+_MATERIAL_UPLOAD_PATH = (
+    "https://mp.weixin.qq.com/cgi-bin/appmsg"
+    "?t=media/videomsg_edit&action=video_edit&type=15&isNew=1"
+    "&token={token}&lang=zh_CN"
+)
+# 合集管理页（合集数据来源，type=5 为视频合集），token 由 _resolve_token 拼装。
+_ALBUM_MGR_PATH = (
+    "https://mp.weixin.qq.com/cgi-bin/appmsgalbummgr"
+    "?action=list&token={token}&lang=zh_CN&type=5"
+)
+
+# 创作来源声明：前端文案 → 公众号弹窗内 radio 的 value。
+# 文档要求「素材来源官方媒体/网络新闻」(value=2) 暂时从选项里移除，故不在此映射。
+_CLAIM_SOURCE_MAP = {
+    "内容由AI生成": "1",
+    "内容剧情演绎，仅供娱乐": "3",
+    "个人观点，仅供参考": "4",
+    "健康医疗分享，仅供参考": "5",
+    "投资观点，仅供参考": "6",
+    "无需声明": "0",
+}
 
 # Cookie 失效时公众号会跳转/渲染的登录页或失效提示标记。
 # 任一命中即视为失效，不再依赖单一精确业务登录 URL。
@@ -83,6 +111,26 @@ class WeixinGzhPlatform(BasePlatform):
                 f"?t=home/index&lang=zh_CN&token={token}"
             )
         return _LOGIN_URL
+
+    @staticmethod
+    async def _resolve_token(page) -> str:
+        """访问公众号首页，等待 cookie 触发跳转，解析并返回最新 token。
+
+        所有带 token 的功能 URL（素材上传、合集管理）都必须用这个方法
+        获取当前会话的有效 token —— token 每次会话会变，不能复用历史值。
+        """
+        await page.goto(_LOGIN_URL, wait_until="domcontentloaded", timeout=30000)
+        # cookie 触发自动跳转到 /cgi-bin/home?...&token=XXX 需要一点时间
+        deadline = asyncio.get_event_loop().time() + 15
+        token = ""
+        while asyncio.get_event_loop().time() < deadline:
+            token = WeixinGzhPlatform._extract_token(page)
+            if token:
+                break
+            await asyncio.sleep(0.5)
+        if not token:
+            logger.warning("[token] 未能从首页 URL 解析到 token, 当前 URL: %s", page.url)
+        return token
 
     def _parse_cookie_to_storage_state(
         self, cookie_str: str
@@ -437,8 +485,1332 @@ class WeixinGzhPlatform(BasePlatform):
         thread.start()
 
     # ------------------------------------------------------------------
-    # publish_video — 暂未实现（公众号以图文为主，发布流程另开任务）
+    # publish_video — 公众号视频发布（同步入口）
     # ------------------------------------------------------------------
 
     def publish_video(self, **kwargs) -> bool:
-        raise NotImplementedError("微信公众号发布功能暂未实现")
+        """Publish a video to WeChat Official Account (sync wrapper).
+
+        Accepted keyword arguments (与其它平台保持一致):
+
+        - ``title`` (*str*) -- 视频标题(≤64 字)
+        - ``files`` (*list[str]*) -- 视频绝对路径(app.py 解析过)
+        - ``tags`` (*list[str]*) -- 话题,拼成 #话题 写进描述(占位)
+        - ``account_file`` (*list[str]*) -- cookie 文件名列表
+        - ``thumbnail_landscape_169_path`` (*str*, optional) -- 16:9 封面(公众号固定用 16:9)
+        - ``thumbnail_landscape_path`` / ``thumbnail_portrait_path`` -- 兜底封面
+        - ``desc`` (*str*, optional) -- 视频介绍(≤300 字, 含 # 标签)
+        - ``is_original`` (*bool*, optional) -- 声明原创
+        - ``gzh_collection_name`` (*str*, optional) -- 合集名
+        - ``gzh_claim_source`` (*str*, optional) -- 创作来源(文案)
+        - ``enableTimer`` (*bool*, optional) -- 定时发布
+        - ``schedule_time_str`` (*str*, optional) -- 定时时间
+        """
+        asyncio.run(self._upload_all(**kwargs))
+        return True
+
+    # ------------------------------------------------------------------
+    # Internal: upload all (files × accounts)
+    # ------------------------------------------------------------------
+
+    async def _upload_all(self, **kwargs):
+        """files × accounts 笛卡尔积编排(与微博保持一致)。"""
+        logger.info("=" * 60)
+        logger.info("[发布视频] 开始微信公众号视频发布流程")
+        logger.info("=" * 60)
+
+        logger.info("[发布参数] 接收到的所有参数:")
+        for key, value in kwargs.items():
+            logger.info("[发布参数]   %s = %s (类型: %s)", key, value, type(value).__name__)
+
+        title = kwargs.get("title", "")
+        files = kwargs.get("files", []) or []
+        tags = kwargs.get("tags", []) or []
+        account_file = kwargs.get("account_file", []) or []
+        thumbnail_169 = kwargs.get("thumbnail_landscape_169_path")
+        thumbnail_landscape = kwargs.get("thumbnail_landscape_path")
+        thumbnail_portrait = kwargs.get("thumbnail_portrait_path")
+        desc = kwargs.get("desc", "") or ""
+        is_original = kwargs.get("is_original", False)
+        gzh_collection_name = kwargs.get("gzh_collection_name", "") or ""
+        gzh_claim_source = kwargs.get("gzh_claim_source", "") or ""
+        enable_timer = kwargs.get("enableTimer", False)
+        schedule_time_str = kwargs.get("schedule_time_str", "")
+
+        logger.info("[发布参数] 标题: %s", title)
+        logger.info("[发布参数] 文件数量: %d", len(files))
+        logger.info("[发布参数] 标签: %s", tags)
+        logger.info("[发布参数] 账号数量: %d", len(account_file))
+        logger.info("[发布参数] 16:9 封面: %s", thumbnail_169 or "无")
+        logger.info("[发布参数] 横版封面: %s", thumbnail_landscape or "无")
+        logger.info("[发布参数] 竖版封面: %s", thumbnail_portrait or "无")
+        logger.info("[发布参数] 原创: %s", is_original)
+        logger.info("[发布参数] 合集: %s", gzh_collection_name or "无")
+        logger.info("[发布参数] 创作来源: %s", gzh_claim_source or "无")
+        logger.info("[发布参数] 定时发布: %s", enable_timer)
+
+        # 公众号封面固定使用 16:9;前端没传 169 时用横版兜底
+        cover_path = thumbnail_169 or thumbnail_landscape or thumbnail_portrait
+
+        account_paths = [str(Path(BASE_DIR / "cookiesFile") / f) for f in account_file]
+        file_paths = [str(f) for f in files]
+        if cover_path:
+            cover_path = str(cover_path)
+
+        for file_index, file_path in enumerate(file_paths):
+            logger.info("-" * 40)
+            logger.info("[发布进度] 处理第 %d/%d 个视频: %s", file_index + 1, len(file_paths), file_path)
+            for cookie_index, cookie_path in enumerate(account_paths):
+                cookie_name = Path(cookie_path).name
+                nick = get_account_name_by_cookie_file(cookie_name)
+                with bind_account_name(nick or "-"):
+                    logger.info("[发布进度] 发布到第 %d/%d 个账号 (%s)", cookie_index + 1, len(account_paths), nick or "未知")
+                    await self._upload_one_video(
+                        title=title,
+                        file_path=file_path,
+                        tags=tags,
+                        account_file=cookie_path,
+                        cover_path=cover_path,
+                        desc=desc,
+                        is_original=is_original,
+                        gzh_collection_name=gzh_collection_name,
+                        gzh_claim_source=gzh_claim_source,
+                        enable_timer=enable_timer,
+                        schedule_time_str=schedule_time_str,
+                        files_count=len(file_paths),
+                    )
+
+        logger.info("=" * 60)
+        logger.info("[发布视频] 视频发布流程完成!")
+        logger.info("=" * 60)
+
+    # ------------------------------------------------------------------
+    # Internal: upload one video to one account (two-stage flow)
+    # ------------------------------------------------------------------
+
+    async def _upload_one_video(
+        self,
+        title: str,
+        file_path: str,
+        tags: list,
+        account_file: str,
+        cover_path=None,
+        desc="",
+        is_original=False,
+        gzh_collection_name="",
+        gzh_claim_source="",
+        enable_timer=False,
+        schedule_time_str="",
+        files_count=1,
+    ):
+        """单视频单账号完整两阶段发布。
+
+        阶段① 素材上传页 videomsg_edit: 传视频→封面→标题→原创→服务规则→保存并发表
+        阶段② 发布编辑页 appmsg_edit_v2(新 tab): 标题/描述→合集→创作来源→发表/定时
+        """
+        browser = await self.create_browser(headless=False)
+        try:
+            context = await self.create_context(
+                browser,
+                storage_state=account_file,
+                user_agent=(
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/127.0.4324.150 Safari/537.36"
+                ),
+            )
+            try:
+                page = await context.new_page()
+
+                # 解析当前会话 token
+                token = await self._resolve_token(page)
+                if not token:
+                    raise RuntimeError("[发布] 未能获取 token,cookie 可能已失效")
+                logger.info("[发布] 获取到 token: %s", token)
+
+                # ===== 阶段① 素材上传页 =====
+                material_url = _MATERIAL_UPLOAD_PATH.format(token=token)
+                logger.info("[阶段①] 打开素材上传页: %s", material_url)
+                await page.goto(material_url, wait_until="domcontentloaded", timeout=30000)
+                await asyncio.sleep(2)
+
+                # 1. 上传视频文件
+                logger.info("[阶段①] 上传视频文件: %s", os.path.basename(file_path))
+                await self._upload_video_file(page, file_path)
+
+                # 2. 等待视频上传完成
+                logger.info("[阶段①] 等待视频上传完成...")
+                await self._wait_for_video_uploaded(page)
+                logger.info("[阶段①] 视频上传成功!")
+
+                # 3. 封面(公众号固定 16:9)
+                if cover_path:
+                    logger.info("[阶段①] 开始设置封面...")
+                    await self._set_cover(page, cover_path)
+                    logger.info("[阶段①] 封面设置完成")
+                else:
+                    logger.info("[阶段①] 未提供封面,跳过")
+
+                # 4. 标题
+                logger.info("[阶段①] 填写标题: %s", title)
+                await self._fill_material_title(page, title)
+
+                # 5. 原创声明
+                if is_original:
+                    logger.info("[阶段①] 开启原创声明...")
+                    await self._set_original(page)
+                else:
+                    logger.info("[阶段①] 未开启原创,跳过")
+
+                # 6. 勾选服务规则
+                logger.info("[阶段①] 勾选服务规则...")
+                await self._check_service_rule(page)
+
+                # 7. 保存并发表(打开新 tab 进入阶段②)
+                logger.info("[阶段①] 点击「保存并发表」,等待新页面打开...")
+                page2 = await self._click_save_and_send(page, context)
+                logger.info("[阶段②] 新页面已打开: %s", page2.url)
+
+                # ===== 阶段② 发布编辑页 =====
+                await page2.wait_for_load_state("domcontentloaded", timeout=30000)
+                await asyncio.sleep(2)
+
+                # 1. 再次填标题(发布页标题独立于素材标题)
+                logger.info("[阶段②] 填写发布页标题: %s", title)
+                await self._fill_publish_title(page2, title)
+
+                # 2. 描述(含 # 标签)
+                logger.info("[阶段②] 填写描述/标签...")
+                await self._fill_description(page2, desc, title, tags)
+
+                # 3. 合集
+                if gzh_collection_name:
+                    logger.info("[阶段②] 选择合集: %s", gzh_collection_name)
+                    await self._set_collection(page2, gzh_collection_name)
+                else:
+                    logger.info("[阶段②] 未选择合集,跳过")
+
+                # 4. 创作来源
+                if gzh_claim_source:
+                    logger.info("[阶段②] 设置创作来源: %s", gzh_claim_source)
+                    await self._set_claim_source(page2, gzh_claim_source)
+                else:
+                    logger.info("[阶段②] 未设置创作来源,跳过")
+
+                # 5. 发表(立即 / 定时)
+                if enable_timer and schedule_time_str:
+                    publish_dt = self._build_publish_datetime(schedule_time_str, files_count)
+                    if publish_dt and not (isinstance(publish_dt, int) and publish_dt == 0):
+                        logger.info("[阶段②] 定时发布: %s", publish_dt)
+                        await self._publish_scheduled(page2, publish_dt)
+                    else:
+                        logger.info("[阶段②] 定时时间解析失败,改为立即发表")
+                        await self._publish_immediate(page2)
+                else:
+                    logger.info("[阶段②] 立即发表...")
+                    await self._publish_immediate(page2)
+
+                logger.info("[发布] 视频发布成功!")
+
+                # 保存 cookie
+                await context.storage_state(path=account_file)
+                logger.info("[发布] Cookie 状态已更新")
+                await asyncio.sleep(2)
+            finally:
+                await context.close()
+        finally:
+            await self.close_browser(browser, is_close_by_code=True)
+
+    # ------------------------------------------------------------------
+    # Helper: parse schedule datetime
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _build_publish_datetime(schedule_time_str, total_files):
+        """解析定时发布时间为本地 datetime,失败返回 0。
+
+        公众号定时只能选最近 7 天(含当天),且时间必须 > 当前 + 1 小时,
+        交给 _publish_scheduled 在选择时处理;此处仅做解析。
+        """
+        result = parse_schedule_time(
+            schedule_time_str, total_files, True, None, None, None,
+        )
+        if result:
+            return result[0]
+        return 0
+
+    # ------------------------------------------------------------------
+    # Stage ① helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def _upload_video_file(page, file_path: str):
+        """上传视频主文件。
+
+        素材上传页的 file input 形如:
+          <input title="上传视频" name="vid" type="file" accept="video/*"
+                 class="weui-desktop-upload-input">
+        直接 set_input_files 即可(与微博不同,公众号的上传 input 在 DOM 中常驻)。
+        """
+        file_size = os.path.getsize(file_path)
+        logger.info(
+            "[阶段①] 准备上传视频: %s (%.1f MB)",
+            os.path.basename(file_path), file_size / 1024 / 1024,
+        )
+        upload_input = page.locator("input[type='file'][name='vid']").first
+        await upload_input.wait_for(state="attached", timeout=15000)
+        await upload_input.set_input_files(file_path)
+        logger.info("[阶段①] 视频文件已提交,等待上传...")
+
+    @staticmethod
+    async def _wait_for_video_uploaded(page, timeout_s: int = 14400):
+        """等待视频上传完成。
+
+        权威信号: ``.weui-desktop-upload__file__extra-info`` 内出现
+        「视频上传成功」文本(DOM 见需求文档):
+          <p class="tips_global">视频上传成功，你可以继续编辑其它信息保存提交</p>
+
+        上传过程中有进度 DOM(剩余时间/速度/已上传百分比),打印进度的旁证日志。
+        失败信号:「转码失败」。
+
+        **可见性是关键**: 公众号页面初始 DOM 里就常驻「视频上传成功」「转码失败」
+        两段模板文案(包在 ``display:none`` 的 mask/tips 容器里),只有对应状态触发
+        时容器才显示。因此必须用 JS 判断元素真正可见(offsetParent != null),
+        否则一进上传就误判成功/失败。
+
+        默认超时 4 小时(大视频 + 慢网络留余量)。
+        """
+        deadline = asyncio.get_event_loop().time() + timeout_s
+        last_progress = ""
+        while asyncio.get_event_loop().time() < deadline:
+            # 成功信号: 文本「视频上传成功」且元素可见
+            try:
+                success_visible = await page.evaluate(
+                    """() => {
+                        const all = Array.from(document.querySelectorAll('*'));
+                        const hit = all.find(el =>
+                            el.children.length === 0 &&
+                            (el.textContent || '').indexOf('视频上传成功') !== -1 &&
+                            el.offsetParent !== null
+                        );
+                        return !!hit;
+                    }"""
+                )
+                if success_visible:
+                    logger.info("[阶段①] 检测到「视频上传成功」")
+                    return
+            except Exception:
+                pass
+            # 失败信号: 文本「转码失败」且其 mask 容器可见
+            try:
+                fail_visible = await page.evaluate(
+                    """() => {
+                        const masks = document.querySelectorAll(
+                            '.weui-desktop-mask_status, .weui-desktop-mask_msg'
+                        );
+                        for (const m of masks) {
+                            if (m.offsetParent === null) continue;
+                            if ((m.textContent || '').indexOf('转码失败') !== -1) {
+                                return true;
+                            }
+                        }
+                        return false;
+                    }"""
+                )
+                if fail_visible:
+                    raise RuntimeError("[阶段①] 视频转码失败,无法继续")
+            except RuntimeError:
+                raise
+            except Exception:
+                pass
+            # 进度旁证
+            try:
+                pct = await page.locator(
+                    ".weui-desktop-upload__file__extra-info__item"
+                ).all_inner_texts()
+                progress = " | ".join(t.strip() for t in pct if t.strip())
+                if progress and progress != last_progress:
+                    logger.info("[阶段①] 上传进度: %s", progress)
+                    last_progress = progress
+            except Exception:
+                pass
+            await asyncio.sleep(5)
+        raise RuntimeError(f"[阶段①] 视频上传等待超时({timeout_s}s)")
+
+    @staticmethod
+    async def _set_cover(page, cover_path: str):
+        """设置视频封面(固定 16:9)。
+
+        流程(文档):
+          1. 上传视频后出现 ``.cover__options__item_empty``(从图片库选择),点击
+          2. 弹窗内出现隐藏的 ``input[type=file][accept*='image']``,set_input_files
+          3. 等「下一步」按钮去掉 weui-desktop-btn_disabled 后点击
+          4. 等「完成」按钮可点后点击,完成封面设置
+        """
+        # 1. 点击「从图片库选择」空位
+        empty_item = page.locator(".cover__options__item_empty").first
+        await empty_item.wait_for(state="visible", timeout=15000)
+        await asyncio.sleep(1)
+        await empty_item.click()
+        logger.info("[阶段①] 已点击「从图片库选择」,等待封面上传弹窗...")
+
+        # 2. 上传封面文件(弹窗内的隐藏 input)
+        cover_input = page.locator("input[type='file'][accept*='image']").first
+        await cover_input.wait_for(state="attached", timeout=15000)
+        await cover_input.set_input_files(cover_path)
+        logger.info("[阶段①] 封面文件已提交: %s", os.path.basename(cover_path))
+        await asyncio.sleep(3)
+
+        # 3. 等「下一步」按钮可点后点击
+        await WeixinGzhPlatform._click_primary_when_enabled(
+            page, "下一步", timeout_s=60,
+        )
+        logger.info("[阶段①] 已点击「下一步」,等待「完成」按钮...")
+
+        # 4. 等「完成」按钮可点后点击
+        await asyncio.sleep(2)
+        await WeixinGzhPlatform._click_primary_when_enabled(
+            page, "完成", timeout_s=60,
+        )
+        logger.info("[阶段①] 已点击「完成」,封面设置完成")
+        await asyncio.sleep(2)
+
+    @staticmethod
+    async def _click_primary_when_enabled(page, button_text: str, timeout_s: int = 60):
+        """等某个 ``weui-desktop-btn_primary`` 按钮去掉 ``weui-desktop-btn_disabled``
+        后点击(公众号按钮禁用态靠加 disabled class 实现)。
+
+        通过 JS 判断:该按钮同时含 primary 且不含 disabled class。
+        """
+        deadline = asyncio.get_event_loop().time() + timeout_s
+        while asyncio.get_event_loop().time() < deadline:
+            clicked = await page.evaluate(
+                """(text) => {
+                    const btns = document.querySelectorAll(
+                        'button.weui-desktop-btn_primary:not(.weui-desktop-btn_disabled)'
+                    );
+                    for (const b of btns) {
+                        if ((b.textContent || '').trim().indexOf(text) !== -1) {
+                            b.click();
+                            return true;
+                        }
+                    }
+                    return false;
+                }""",
+                button_text,
+            )
+            if clicked:
+                return
+            await asyncio.sleep(1)
+        raise RuntimeError(
+            f"[阶段①] 「{button_text}」按钮在 {timeout_s}s 内未变为可点击状态"
+        )
+
+    @staticmethod
+    async def _fill_material_title(page, title: str):
+        """素材上传页标题:``input[name='title']``,≤64 字。"""
+        title_input = page.locator("input[name='title']").first
+        await title_input.wait_for(state="visible", timeout=10000)
+        await title_input.fill((title or "")[:64])
+        logger.info("[阶段①] 素材标题已填写(%d 字)", len((title or "")[:64]))
+
+    @staticmethod
+    async def _set_original(page):
+        """开启原创声明开关,并确认弹窗。
+
+        DOM(文档):
+          开关: .ori-reward-info_wrp .weui-desktop-switch
+          原创须知弹窗: .weui-desktop-dialog_original-video 内「确定」按钮
+        """
+        switch = page.locator(".ori-reward-info_wrp .weui-desktop-switch").first
+        await switch.wait_for(state="visible", timeout=10000)
+        await switch.click()
+        logger.info("[阶段①] 已点击原创声明开关,等待须知弹窗...")
+        await asyncio.sleep(1.5)
+        # 点弹窗内「确定」
+        ok_clicked = await page.evaluate(
+            """() => {
+                const dialog = document.querySelector('.weui-desktop-dialog_original-video')
+                    || document.querySelector('.weui-desktop-dialog__wrp');
+                if (!dialog) return false;
+                const btns = dialog.querySelectorAll('button.weui-desktop-btn_primary');
+                for (const b of btns) {
+                    b.click();
+                    return true;
+                }
+                return false;
+            }"""
+        )
+        if not ok_clicked:
+            logger.warning("[阶段①] 未找到原创须知弹窗的「确定」按钮")
+        await asyncio.sleep(1)
+
+    @staticmethod
+    async def _check_service_rule(page):
+        """勾选 footer 的《公众平台视频上传服务规则》checkbox。
+
+        DOM(文档): ``.video-setting__footer-link input.weui-desktop-form__checkbox``
+        """
+        cb = page.locator(
+            ".video-setting__footer-link input.weui-desktop-form__checkbox"
+        ).first
+        try:
+            await cb.wait_for(state="attached", timeout=10000)
+        except Exception:
+            logger.warning("[阶段①] 未找到服务规则 checkbox,跳过")
+            return
+        # 仅在未勾选时勾选
+        try:
+            checked = await cb.is_checked()
+        except Exception:
+            checked = False
+        if not checked:
+            # checkbox 常被 label 遮挡,用 JS 直接勾选
+            await cb.evaluate("el => { if (!el.checked) el.click(); }")
+            logger.info("[阶段①] 已勾选服务规则")
+        await asyncio.sleep(0.5)
+
+    @staticmethod
+    async def _click_save_and_send(page, context):
+        """点击「保存并发表」,返回打开的发布编辑页(新 tab)。
+
+        DOM(文档): ``.video-save-send-btn button``
+
+        流程:
+          1. 点「保存并发表」
+          2. 未声明原创时会弹「提交视频」确认框,需点「继续提交」才会开新 tab
+             (声明了原创则可能直接开新 tab)
+          3. 浏览器打开新 tab(发布编辑页 appmsg_edit_v2)
+
+        **关键坑(实测)**: 不能用 ``context.expect_page`` 抢第一个新 tab ——
+        公众号页面会先弹一个 ``about:blank`` 的广告/统计 tab,expect_page 会
+        把它误当成目标页,导致真正的「继续提交」弹窗没人点、流程卡死、
+        最终 watchdog 关闭浏览器。
+
+        正确做法:
+          - 用 ``context.on("page", ...)`` 收集所有新 tab,但只接受 URL 含
+            ``appmsg_edit`` 的(过滤掉 about:blank 广告页);
+          - 显式轮询点击可见的「继续提交」/「继续发布」确认弹窗;
+          - 新 tab 的 URL 一开始可能是 about:blank,要等它导航到 appmsg_edit。
+        """
+        # 监听所有新 tab,记录"可能的目标页"(URL 含 appmsg_edit 的)
+        candidate_holder = {"page": None}
+
+        def _on_new_page(new_page):
+            try:
+                url = new_page.url or ""
+            except Exception:
+                url = ""
+            logger.info("[阶段①] 检测到新 tab: %s", url or "(about:blank)")
+            # 只认发布编辑页;about:blank/广告页忽略(发布页 URL 含 appmsg_edit)
+            if "appmsg_edit" in url:
+                candidate_holder["page"] = new_page
+
+        context.on("page", _on_new_page)
+
+        try:
+            save_send_btn = page.locator(".video-save-send-btn button").first
+            await save_send_btn.wait_for(state="visible", timeout=15000)
+
+            # 「保存并发表」初始可能 disabled,等其可点后点击
+            deadline = asyncio.get_event_loop().time() + 60
+            clicked = False
+            while asyncio.get_event_loop().time() < deadline:
+                disabled = await save_send_btn.evaluate(
+                    "el => el.classList.contains('weui-desktop-btn_disabled')"
+                )
+                if not disabled:
+                    await save_send_btn.click()
+                    clicked = True
+                    break
+                await asyncio.sleep(1)
+            if not clicked:
+                await save_send_btn.click(force=True)
+            logger.info("[阶段①] 已点击「保存并发表」,等待弹窗/新页面...")
+
+            # 轮询: 处理确认弹窗 + 等待目标新 tab 导航到 appmsg_edit
+            #
+            # **可见性是关键**: 页面初始 DOM 里常驻多个 display:none 弹窗模板
+            # (提交视频/视频发布/原创须知),只点 offsetParent !== null 的按钮。
+            #
+            # **导航销毁异常**: 点完「继续提交」后旧页面会发生导航跳转,context
+            # 被销毁,此后对该 page 的 evaluate 会抛 "Execution context was
+            # destroyed"。这恰恰说明弹窗确认生效、正在跳转,应捕获后转去等目标页。
+            wait_deadline = asyncio.get_event_loop().time() + 120
+            handled_dialogs = set()
+            target_page = None
+            while asyncio.get_event_loop().time() < wait_deadline:
+                # 新 tab 可能已出现但 URL 还是 about:blank,补查它的最新 URL
+                if candidate_holder["page"] is not None:
+                    target_page = candidate_holder["page"]
+                    break
+                # 也可在 context.pages 里找已导航到 appmsg_edit 的 tab
+                for p in context.pages:
+                    try:
+                        if p is page:
+                            continue
+                        if "appmsg_edit" in (p.url or ""):
+                            target_page = p
+                            candidate_holder["page"] = p
+                            break
+                    except Exception:
+                        continue
+                if target_page is not None:
+                    break
+
+                # 处理「继续提交」(提交视频弹窗,未声明原创时出现) / 「继续发布」
+                try:
+                    for btn_text in ("继续提交", "继续发布", "继续"):
+                        if btn_text in handled_dialogs:
+                            continue
+                        clicked_dialog = await page.evaluate(
+                            """(text) => {
+                                const btns = document.querySelectorAll(
+                                    '.weui-desktop-dialog button.weui-desktop-btn_primary'
+                                );
+                                for (const b of btns) {
+                                    if ((b.textContent || '').trim().indexOf(text) === -1) continue;
+                                    // 按钮自身必须可见(排除 display:none 模板里的按钮)
+                                    if (b.offsetParent === null) continue;
+                                    b.click();
+                                    return true;
+                                }
+                                return false;
+                            }""",
+                            btn_text,
+                        )
+                        if clicked_dialog:
+                            logger.info("[阶段①] 已点击中间确认弹窗「%s」", btn_text)
+                            handled_dialogs.add(btn_text)
+                            await asyncio.sleep(1.5)
+                            break
+                    else:
+                        await asyncio.sleep(1)
+                except Exception as e:
+                    # 旧页面导航/context 销毁(点了继续提交后跳转),不是错误,
+                    # 转去等目标新 tab 导航到 appmsg_edit
+                    logger.info("[阶段①] 弹窗处理后页面已导航(预期行为): %s", str(e)[:80])
+                    break
+
+            # 等目标页出现并导航到 appmsg_edit(点了继续提交后新 tab 才会跳转)
+            if target_page is None:
+                # 轮询结束时还没拿到,再从 context.pages 兜底找一次
+                for _ in range(30):
+                    for p in context.pages:
+                        try:
+                            if p is page:
+                                continue
+                            if "appmsg_edit" in (p.url or ""):
+                                target_page = p
+                                candidate_holder["page"] = p
+                                break
+                        except Exception:
+                            continue
+                    if target_page is not None:
+                        break
+                    await asyncio.sleep(1)
+
+            if target_page is None:
+                raise RuntimeError(
+                    "[阶段①] 点击「保存并发表」后未捕获到发布编辑页新 tab"
+                )
+
+            # 新 tab 可能还在 about:blank,等它导航到 appmsg_edit
+            try:
+                await target_page.wait_for_url(
+                    "**/appmsg_edit*", timeout=30000,
+                )
+            except Exception as e:
+                logger.info("[阶段①] 新 tab URL 等待(非致命): %s, 当前: %s", e, target_page.url)
+            await target_page.bring_to_front()
+            return target_page
+        finally:
+            context.remove_listener("page", _on_new_page)
+
+    # ------------------------------------------------------------------
+    # Stage ② helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def _fill_publish_title(page, title: str):
+        """发布编辑页标题:``#title textarea.js_title``,≤64 字。
+
+        DOM(文档): 该 textarea 上方有 ProseMirror 覆盖层,直接 fill 即可触发。
+        """
+        title_input = page.locator("#title.js_title").first
+        if await title_input.count() == 0:
+            title_input = page.locator("textarea.js_title").first
+        await title_input.wait_for(state="visible", timeout=15000)
+        await title_input.fill((title or "")[:64])
+        logger.info("[阶段②] 发布页标题已填写(%d 字)", len((title or "")[:64]))
+
+    @staticmethod
+    async def _fill_description(page, desc: str, title: str, tags: list):
+        """填写视频描述(contenteditable ProseMirror),含 # 标签,≤300 字。
+
+        DOM(文档): ``#guide_words_main .ProseMirror``(contenteditable)
+        desc 为空时回落 title;tags 拼成 ``#话题`` 追加。
+        按 CLAUDE.md: contenteditable 用 press_sequentially 逐字符输入,
+        比剪贴板粘贴/keyboard.type 更可靠地触发 React onChange。
+        """
+        editor = page.locator("#guide_words_main .ProseMirror").first
+        await editor.wait_for(state="visible", timeout=15000)
+
+        # 组装最终文本: desc(或回落 title) + # 话题
+        base = (desc or "").strip() or (title or "").strip()
+        tag_parts = [f"#{t.strip()}" for t in (tags or []) if str(t).strip()]
+        tag_text = " ".join(tag_parts)
+        full = f"{base} {tag_text}".strip() if tag_text else base
+        # 截断到 300 字(含 # 标签,文档要求)
+        full = full[:300]
+        if not full:
+            logger.info("[阶段②] 描述为空,跳过")
+            return
+
+        # 先清空(contenteditable: 点击聚焦 + 全选 + 删除)
+        await clear_input(page, element=editor)
+        # press_sequentially: 自动 focus + 逐字符触发 onChange/drop 事件
+        await editor.press_sequentially(full, delay=30)
+        await asyncio.sleep(0.5)
+        logger.info("[阶段②] 描述已填写(%d 字)", len(full))
+
+    @staticmethod
+    async def _set_collection(page, collection_name: str):
+        """设置合集(发布编辑页)。
+
+        流程(文档):
+          1. 点 ``#js_article_tags_area .js_article_tags_label``(未添加区域)
+          2. 弹窗内点 ``input[placeholder='请选择合集']`` 展开下拉
+          3. 下拉 ``li.select-opt-li`` 匹配合集名后点击
+          4. 点弹窗「确认」(``.weui-desktop-dialog__ft`` 内 primary)
+        """
+        # 1. 点击「未添加」入口
+        entry = page.locator("#js_article_tags_area .js_article_tags_label").first
+        await entry.wait_for(state="visible", timeout=10000)
+        await entry.click()
+        logger.info("[阶段②] 已点击合集入口,等待弹窗...")
+        await asyncio.sleep(1.5)
+
+        # 2. 展开合集下拉
+        select_input = page.locator("input[placeholder='请选择合集']").first
+        try:
+            await select_input.wait_for(state="visible", timeout=10000)
+            await select_input.click()
+        except Exception as e:
+            logger.warning("[阶段②] 未找到合集选择输入框: %s", e)
+            return
+        await asyncio.sleep(1)
+
+        # 3. 匹配并点击合集项
+        matched = await page.evaluate(
+            """(name) => {
+                const opts = document.querySelectorAll('li.select-opt-li');
+                for (const li of opts) {
+                    if ((li.textContent || '').trim() === name) {
+                        li.click();
+                        return true;
+                    }
+                }
+                return false;
+            }""",
+            collection_name,
+        )
+        if matched:
+            logger.info("[阶段②] 已选中合集: %s", collection_name)
+        else:
+            logger.warning("[阶段②] 未找到合集「%s」", collection_name)
+        await asyncio.sleep(1)
+
+        # 4. 点「确认」
+        await WeixinGzhPlatform._click_dialog_primary(page, "确认")
+        logger.info("[阶段②] 合集设置完成")
+        await asyncio.sleep(1)
+
+    @staticmethod
+    async def _set_claim_source(page, claim_source: str):
+        """设置创作来源(发布编辑页)。
+
+        流程(文档):
+          1. 点 ``#js_claim_source_area``(未添加区域)
+          2. 弹窗内点对应声明类型 radio(value 见 _CLAIM_SOURCE_MAP)
+          3. 点弹窗「确认」
+
+        注:文档要求「素材来源官方媒体/网络新闻」(value=2)暂从选项移除,
+        因此 _CLAIM_SOURCE_MAP 不含该项。
+        """
+        value = _CLAIM_SOURCE_MAP.get(claim_source)
+        if not value:
+            # 兜底:按文案模糊匹配
+            for label, v in _CLAIM_SOURCE_MAP.items():
+                if claim_source in label or label in claim_source:
+                    value = v
+                    break
+        if not value:
+            logger.warning("[阶段②] 未知创作来源「%s」,跳过", claim_source)
+            return
+
+        # 1. 点击入口
+        # 点「未添加」可点击区域(.js_claim_source_desc),不是整个容器 #js_claim_source_area
+        # —— 后者点的是 label,只会勾选 checkbox 而不会弹出设置弹窗。
+        entry = page.locator("#js_claim_source_area .js_claim_source_desc").first
+        if await entry.count() == 0:
+            entry = page.locator("#js_claim_source_area").first
+        await entry.wait_for(state="visible", timeout=10000)
+        await entry.click()
+        logger.info("[阶段②] 已点击创作来源入口,等待弹窗...")
+        await asyncio.sleep(1.5)
+
+        # 2. 点对应 radio —— 用文案精确定位(比 value 更稳,文案与用户选择直接对应)
+        #    DOM: .weui-desktop-form__check-label > span.weui-desktop-form__check-content(文案)
+        #         同一 label 内 input.weui-desktop-form__radio[value=N]
+        target_label = claim_source
+        radio_clicked = await page.evaluate(
+            """(label) => {
+                const labels = document.querySelectorAll(
+                    '.claim-source_dialog_panel .weui-desktop-form__check-label'
+                );
+                for (const lab of labels) {
+                    const span = lab.querySelector('.weui-desktop-form__check-content');
+                    if (span && (span.textContent || '').trim() === label) {
+                        lab.click();
+                        return true;
+                    }
+                }
+                return false;
+            }""",
+            target_label,
+        )
+        if radio_clicked:
+            logger.info("[阶段②] 已选择创作来源: %s (value=%s)", claim_source, value)
+        else:
+            logger.warning("[阶段②] 未找到创作来源「%s」(value=%s)", claim_source, value)
+        await asyncio.sleep(1)
+
+        # 3. 点「确认」(初始 disabled,选中 radio 后启用)
+        await WeixinGzhPlatform._click_dialog_primary(page, "确认", timeout_s=15)
+        logger.info("[阶段②] 创作来源设置完成")
+        await asyncio.sleep(1)
+
+    @staticmethod
+    async def _click_dialog_primary(page, button_text: str, timeout_s: int = 30):
+        """点击当前可见弹窗(weui-desktop-dialog)内的 primary 按钮(等其去掉 disabled)。
+
+        定位: ``.weui-desktop-dialog:not([style*='display: none']) .weui-desktop-btn_primary``
+        """
+        deadline = asyncio.get_event_loop().time() + timeout_s
+        while asyncio.get_event_loop().time() < deadline:
+            clicked = await page.evaluate(
+                """(text) => {
+                    const dialogs = document.querySelectorAll('.weui-desktop-dialog');
+                    for (const d of dialogs) {
+                        const wrp = d.closest('.weui-desktop-dialog__wrp');
+                        if (wrp && wrp.style && wrp.style.display === 'none') continue;
+                        const btns = d.querySelectorAll(
+                            'button.weui-desktop-btn_primary:not(.weui-desktop-btn_disabled)'
+                        );
+                        for (const b of btns) {
+                            if ((b.textContent || '').trim().indexOf(text) !== -1) {
+                                b.click();
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
+                }""",
+                button_text,
+            )
+            if clicked:
+                return
+            await asyncio.sleep(1)
+        logger.warning("[阶段②] 「%s」按钮在 %ds 内未可点", button_text, timeout_s)
+
+    @staticmethod
+    async def _publish_immediate(page):
+        """立即发表。
+
+        流程:
+          1. 点页面「发表」(#js_send) → 弹出 .mass-send 发表弹窗
+             (含群发通知/定时发表选项,立即发表不碰定时开关)
+          2. 直接点弹窗底部「发表」按钮(.mass-send__footer 内 primary)
+          3. 弹出二次确认弹窗 → 点「继续发表」
+          4. 二次确认后弹扫码确认(用户微信扫码) → 等页面跳转首页
+
+        成功信号: URL 跳转到 /cgi-bin/home
+        """
+        # 1. 点页面「发表」打开发表弹窗
+        send_btn = page.locator("#js_send .mass_send").first
+        await send_btn.wait_for(state="visible", timeout=15000)
+        await send_btn.click()
+        logger.info("[阶段②] 已点击「发表」,等待发表弹窗...")
+        await asyncio.sleep(2)
+
+        # 2. 点弹窗底部「发表」(不开定时开关,直接发)
+        await WeixinGzhPlatform._click_dialog_primary(page, "发表", timeout_s=15)
+        logger.info("[阶段②] 已点击弹窗「发表」,等待确认...")
+
+        # 3. 二次确认弹窗「继续发表」(若有)
+        await asyncio.sleep(2)
+        await WeixinGzhPlatform._click_dialog_primary(page, "继续发表", timeout_s=15)
+        logger.info("[阶段②] 已点击「继续发表」,等待跳转首页...")
+
+        # 4. 二次确认后公众号会弹扫码确认(管理员微信扫码),扫码通过后页面才跳转。
+        #    这里只等页面跳转到首页/成功页,不点任何按钮 —— 扫码是用户线下动作。
+        #    给 10 分钟供用户扫码。
+        await WeixinGzhPlatform._wait_for_home(page, timeout_s=600)
+
+    @staticmethod
+    async def _publish_scheduled(page, publish_dt):
+        """定时发表。
+
+        DOM(文档):
+          发表按钮点开后弹窗,内有定时开关 ``.mass-send__timer-wrp .weui-desktop-switch``
+          日期下拉 ``.weui-desktop-form__dropdown``,时间选择 ``.weui-desktop-picker__time``
+          发表: ``.weui-desktop-btn_primary``(弹窗内「发表」,在 .mass-send__footer)
+
+        **重要(实测)**: 发表弹窗里有两个开关:
+          - 群发通知开关(.mass-send__td 下的 .mass-send__timer-wrp):常 disabled
+            (今天没有通知次数),不要碰它;
+          - 定时发表开关(.mass-send__td-setting 下的 .mass-send__timer-wrp):
+            这个是要点的,点开后展开日期/时间选择。
+        两个开关都常驻 ``weui-desktop-switch_loading`` 类(weui 组件固定样式,
+        不是"加载中"含义)。**不需要扫码确认** —— 之前误判成扫码是错的。
+
+        约束(文档): 系统设置的发布日期只能选最近 7 天(含当天),
+        且时间必须 > 当前时间至少 1 小时。
+        """
+        # 1. 点「发表」打开弹窗
+        send_btn = page.locator("#js_send .mass_send").first
+        await send_btn.wait_for(state="visible", timeout=15000)
+        await send_btn.click()
+        logger.info("[阶段②] 已点击「发表」,等待定时弹窗...")
+        await asyncio.sleep(2)
+
+        # 2. 开启「定时发表」开关
+        #    弹窗里有两个开关:群发通知(input 带 disabled)、定时发表(可用)。
+        #    取「input 未 disabled 且当前未勾选」的开关点击。
+        #    **关键(实测根因)**: 点完必须校验 input.checked===true 且时间选择器
+        #    dl 不再 display:none —— 否则后续选时分全无效(dl 隐藏,点不到)。
+        #    之前只 return 'ok' 不校验,导致开关没真开就往下走。
+        switched = False
+        sw_deadline = asyncio.get_event_loop().time() + 20
+        attempt = 0
+        while asyncio.get_event_loop().time() < sw_deadline:
+            res = await page.evaluate(
+                """() => {
+                    const switches = document.querySelectorAll(
+                        '.mass-send__timer-wrp .weui-desktop-switch'
+                    );
+                    const out = {clicked: false, checked: false, reason: 'none'};
+                    for (const sw of switches) {
+                        const input = sw.querySelector('input.weui-desktop-switch__input');
+                        if (!input) continue;
+                        if (input.disabled) { out.reason = 'disabled'; continue; }  // 群发通知开关
+                        if (input.checked) { out.checked = true; out.reason = 'already-on'; continue; }
+                        sw.click();
+                        out.clicked = true;
+                        out.reason = 'clicked';
+                        break;
+                    }
+                    return out;
+                }"""
+            )
+            await asyncio.sleep(0.8)
+            # 校验: 开关 checked 且 时间选择器 dl 可见
+            verify = await page.evaluate(
+                """() => {
+                    const switches = document.querySelectorAll(
+                        '.mass-send__timer-wrp .weui-desktop-switch'
+                    );
+                    let on = false;
+                    for (const sw of switches) {
+                        const input = sw.querySelector('input.weui-desktop-switch__input');
+                        if (input && !input.disabled && input.checked) { on = true; break; }
+                    }
+                    const dl = document.querySelector('dl.weui-desktop-picker__time');
+                    let dlHidden = false;
+                    if (dl) {
+                        const styleAttr = dl.getAttribute('style') || '';
+                        const computed = window.getComputedStyle(dl).display;
+                        dlHidden = styleAttr.replace(' ', '').indexOf('display:none') !== -1
+                                   || computed === 'none';
+                    }
+                    return {on, dlHidden, dlExists: !!dl};
+                }"""
+            )
+            logger.info(
+                "[阶段②][开关] 第%d次 res=%s verify=%s", attempt, res, verify
+            )
+            if verify.get("on") and not verify.get("dlHidden"):
+                switched = True
+                break
+            attempt += 1
+        if switched:
+            logger.info("[阶段②] 已开启「定时发表」开关(校验通过: dl 已可见)")
+        else:
+            logger.error("[阶段②] 定时开关校验失败:开关未开或时间选择器仍 display:none")
+        await asyncio.sleep(1.0)
+
+        # 3. 选择日期(最近 7 天的下拉,按目标日期匹配)
+        target_date_label = WeixinGzhPlatform._resolve_date_label(publish_dt)
+        await WeixinGzhPlatform._select_schedule_date(page, target_date_label)
+
+        # 4. 选择时间(时/分滚轮)
+        target_hour = publish_dt.strftime("%H")
+        target_minute = publish_dt.strftime("%M")
+        await WeixinGzhPlatform._select_schedule_time(page, target_hour, target_minute)
+
+        # 5. 点弹窗内「发表」(.mass-send__footer 内 primary)
+        await WeixinGzhPlatform._click_dialog_primary(page, "发表", timeout_s=15)
+        logger.info("[阶段②] 已点击定时「发表」,等待确认...")
+
+        # 6. 二次确认「继续发表」(若有)
+        await asyncio.sleep(2)
+        await WeixinGzhPlatform._click_dialog_primary(page, "继续发表", timeout_s=15)
+        logger.info("[阶段②] 已点击「继续发表」,等待定时发布提交...")
+        # 二次确认后公众号会弹扫码确认(管理员微信扫码),扫码通过后页面才跳转。
+        # 这里只等页面跳转到首页/成功页,不点任何按钮 —— 扫码是用户线下动作。
+        await WeixinGzhPlatform._wait_for_home(page, timeout_s=600)
+
+    @staticmethod
+    def _resolve_date_label(publish_dt):
+        """把目标日期映射到公众号下拉的文案(今天/明天/M月D日)。
+
+        公众号下拉只提供最近 7 天的选项,文案为「今天」「明天」或「M月D日」。
+        """
+        from datetime import date
+        today = date.today()
+        target = publish_dt.date()
+        delta = (target - today).days
+        if delta == 0:
+            return "今天"
+        if delta == 1:
+            return "明天"
+        return f"{target.month}月{target.day}日"
+
+    @staticmethod
+    async def _select_schedule_date(page, date_label: str):
+        """选择定时日期:点开日期下拉,匹配文案。"""
+        # 点日期下拉 trigger
+        dropdown = page.locator(".mass-send__timer .weui-desktop-form__dropdown").first
+        try:
+            await dropdown.wait_for(state="visible", timeout=5000)
+            await dropdown.click()
+            await asyncio.sleep(0.5)
+        except Exception as e:
+            logger.warning("[阶段②] 未找到日期下拉: %s", e)
+            return
+        # 点匹配的选项
+        matched = await page.evaluate(
+            """(label) => {
+                const items = document.querySelectorAll(
+                    '.weui-desktop-dropdown__list-ele .weui-desktop-dropdown__list-ele__text'
+                );
+                for (const it of items) {
+                    if ((it.textContent || '').trim() === label) {
+                        it.closest('.weui-desktop-dropdown__list-ele').click();
+                        return true;
+                    }
+                }
+                return false;
+            }""",
+            date_label,
+        )
+        if matched:
+            logger.info("[阶段②] 已选择定时日期: %s", date_label)
+        else:
+            logger.warning("[阶段②] 未找到定时日期选项「%s」", date_label)
+        await asyncio.sleep(0.5)
+
+    @staticmethod
+    def _find_visible_picker_dl_js() -> str:
+        """JS 片段: 返回当前可见(非 display:none)的那个 ``dl.weui-desktop-picker__time``。
+
+        页面上常驻两个该选择器 dl(实测 input_count=2):
+          - 一个 ``style="display: none"`` 的废弃/模板 dl;
+          - 一个真正可见、要操作的 dl(开关打开后才渲染)。
+        旧代码用 ``querySelector`` 永远取到第一个(恰好是隐藏的),导致时分一直点不到。
+        这里遍历全部 dl,挑出 ``getComputedStyle().display !== 'none'`` 的那个返回,
+        返回 DOM 元素引用(供后续 JS 复用)。
+        """
+        return (
+            "() => {"
+            "  const dls = Array.from(document.querySelectorAll('dl.weui-desktop-picker__time'));"
+            "  const vis = dls.filter(d => window.getComputedStyle(d).display !== 'none');"
+            "  return vis.length ? vis[0] : (dls.length ? dls[0] : null);"
+            "}"
+        )
+
+    @staticmethod
+    async def _select_schedule_time(page, hour: str, minute: str):
+        """选择定时时间:展开时分面板 → 选时/分 → 点外部关闭。
+
+        交互(用户实测确认):
+          1. 点击时间选择器 ``<dl.weui-desktop-picker__time>`` 的触发区(dt 内的
+             input「请选择时间」/dt 本身) → dl 获得 ``weui-desktop-picker__focus``,
+             下方原本隐藏的 ``dd`` 时分面板随之显示出来;
+          2. 在 hour 列表(``ol.weui-desktop-picker__time__hour``)点目标小时 li,
+             在 minute 列表(``ol.weui-desktop-picker__time__minute``)点目标分钟 li;
+             li 文本为纯数字('00'..'23'/'00'..'59'),禁用项带
+             ``weui-desktop-picker__disabled``,选中项带 ``weui-desktop-picker__selected``;
+          3. 点击组件外页面其他位置 → 关闭面板,时分选择生效。
+
+        **关键坑(定时时间一直选不上的真正根因)**:
+          页面上常驻 **两个** ``dl.weui-desktop-picker__time``(实测 input_count=2):
+          一个 ``display:none`` 的废弃 dl,一个可见、要操作的 dl。
+          旧代码/Playwright ``querySelector``/``locator(...).first`` 永远取到第一个
+          (恰好是隐藏的),所以触发区点击 ``scroll_into_view_if_needed`` 必然超时、
+          时分 li 也根本点不到。本方法所有 DOM 操作都基于「**可见的那个 dl**」:
+          先用 JS 遍历挑出可见 dl,再在它内部点触发区/选时分。
+        """
+        hour = str(hour).zfill(2)
+        minute = str(minute).zfill(2)
+        logger.info("[阶段②][时间] 进入 _select_schedule_time, 目标 %s:%s", hour, minute)
+
+        # 0. 探测页面 dl/input 现状 —— 关键: 遍历所有 dl, 区分可见/隐藏, 找出目标 dl。
+        probe = await page.evaluate(
+            """() => {
+                const dls = Array.from(document.querySelectorAll('dl.weui-desktop-picker__time'));
+                const inputs = Array.from(document.querySelectorAll('input[placeholder="请选择时间"]'));
+                const r = (el) => { if (!el) return null; const b = el.getBoundingClientRect();
+                    return {x:Math.round(b.x), y:Math.round(b.y), w:Math.round(b.width), h:Math.round(b.height),
+                            visible: b.width>0 && b.height>0,
+                            style: el.getAttribute('style') || '',
+                            display: window.getComputedStyle(el).display}; };
+                return {
+                    dl_total: dls.length,
+                    dl_visible_count: dls.filter(d => window.getComputedStyle(d).display !== 'none').length,
+                    dls: dls.map((d,i)=>({i, focus: d.classList.contains('weui-desktop-picker__focus'), box:r(d)})),
+                    input_total: inputs.length,
+                    input_visible_count: inputs.filter(inp => window.getComputedStyle(inp).display !== 'none').length,
+                    inputs: inputs.map((inp,i)=>({i, box:r(inp)})),
+                };
+            }"""
+        )
+        logger.info("[阶段②][时间] DOM 探测: %s", probe)
+
+        # 1. 点击触发区展开面板 —— 全部基于「可见 dl」内部元素。
+        #    展开的权威信号: 可见 dl 出现 weui-desktop-picker__focus。
+        #    候选触发点(都在目标 dl 内部): input → dt → 时钟图标 → dl 本身。
+        #    用一段 JS 同时完成「找可见 dl + 点指定候选」,避开 Playwright
+        #    locator.first 永远命中隐藏 dl 的问题。
+        FIND_DL = WeixinGzhPlatform._find_visible_picker_dl_js()
+
+        async def _is_focused():
+            """返回可见 dl 当前是否带 __focus。"""
+            return await page.evaluate(
+                "() => {"
+                " const dl = (" + FIND_DL + ")();"
+                " return !!(dl && dl.classList.contains('weui-desktop-picker__focus'));"
+                "}"
+            )
+
+        # innerSel 候选: '' 表示点 dl 本身; 否则在 dl 内 querySelector
+        candidates = [
+            ("input", "input[placeholder='请选择时间']"),
+            ("dt",    "dt.weui-desktop-picker__dt"),
+            ("icon",  ".weui-desktop-icon__time"),
+            ("dl-self", ""),
+        ]
+
+        opened = False
+        op_deadline = asyncio.get_event_loop().time() + 10
+        attempt = 0
+        while asyncio.get_event_loop().time() < op_deadline:
+            before = await _is_focused()
+            if before:
+                opened = True
+                break
+            name, inner_sel = candidates[attempt % len(candidates)]
+            clicked = await page.evaluate(
+                """(innerSel) => {
+                    const dl = (""" + FIND_DL + """)();
+                    if (!dl) return {ok:false, reason:'no-visible-dl'};
+                    const target = innerSel === '' ? dl : dl.querySelector(innerSel);
+                    if (!target) return {ok:false, reason:'no-target', innerSel};
+                    const b = target.getBoundingClientRect();
+                    if (b.width === 0 && b.height === 0) return {ok:false, reason:'target-not-visible', box:{w:b.width,h:b.height}};
+                    target.click();
+                    return {ok:true, box:{x:Math.round(b.x),y:Math.round(b.y),w:Math.round(b.width),h:Math.round(b.height)}};
+                }""",
+                inner_sel,
+            )
+            await asyncio.sleep(0.6)
+            after = await _is_focused()
+            logger.info(
+                "[阶段②][时间] 第%d次 点可见dl内「%s」 result=%s focus:%s->%s",
+                attempt, name, clicked, before, after,
+            )
+            if after:
+                opened = True
+                break
+            attempt += 1
+            await asyncio.sleep(0.3)
+        if not opened:
+            final_probe = await page.evaluate(
+                """() => {
+                    const dls = Array.from(document.querySelectorAll('dl.weui-desktop-picker__time'));
+                    return dls.map((d,i)=>({i, focus:d.classList.contains('weui-desktop-picker__focus'),
+                        display: window.getComputedStyle(d).display,
+                        style: d.getAttribute('style') || '',
+                        head: d.outerHTML.slice(0,160)}));
+                }"""
+            )
+            logger.warning(
+                "[阶段②][时间] 时分选择面板未展开(__focus 未出现),放弃选择时间. 全部 dl: %s",
+                final_probe,
+            )
+            return
+        logger.info("[阶段②][时间] 时分选择面板已展开(尝试 %d 次)", attempt + 1)
+
+        # 2. 选小时(在可见 dl 内部,跳过禁用项,文本 trim 后匹配;校验是否真选中)
+        logger.info("[阶段②][时间] 开始选小时 %s", hour)
+        h_ok = await WeixinGzhPlatform._click_time_wheel_item(
+            page, "hour", hour
+        )
+        logger.info("[阶段②][时间] 选小时 %s: %s", hour, "成功" if h_ok else "未找到")
+
+        # 3. 选分钟
+        logger.info("[阶段②][时间] 开始选分钟 %s", minute)
+        m_ok = await WeixinGzhPlatform._click_time_wheel_item(
+            page, "minute", minute
+        )
+        logger.info("[阶段②][时间] 选分钟 %s: %s", minute, "成功" if m_ok else "未找到")
+        await asyncio.sleep(0.5)
+
+        # 4. 点击组件外部 → 关闭面板,选择生效
+        try:
+            await page.mouse.click(10, 10)
+            await asyncio.sleep(0.5)
+            still_open = await _is_focused()
+            if still_open:
+                logger.info("[阶段②][时间] 点(10,10)未关闭面板,补按 Escape")
+                await page.keyboard.press("Escape")
+                await asyncio.sleep(0.3)
+        except Exception as e:
+            logger.warning("[阶段②][时间] 关闭面板异常: %s, 尝试 Escape", str(e)[:100])
+            try:
+                await page.keyboard.press("Escape")
+            except Exception:
+                pass
+
+        # 5. 校验 可见 dl 内 input 显示值是否真的变成 HH:MM(选择生效铁证)
+        final_value = await page.evaluate(
+            "() => {"
+            " const dl = (" + FIND_DL + ")();"
+            " if (!dl) return {value: null, reason: 'no-visible-dl'};"
+            " const inp = dl.querySelector('input[placeholder=\"请选择时间\"]');"
+            " return {value: inp ? (inp.value || '') : null};"
+            "}"
+        )
+        logger.info(
+            "[阶段②][时间] 完成设置, 目标 %s:%s, 可见dl input 实际值=%r",
+            hour, minute, final_value,
+        )
+
+    @staticmethod
+    def _wheel_items_js_body(kind: str) -> str:
+        """生成 JS 片段(不带外层函数): 取「可见 dl」内 hour/minute 滚轮的所有 li。
+
+        kind 为 'hour' 或 'minute',对应 ol.weui-desktop-picker__time__hour / __minute。
+        关键: 只在「可见 dl」内查 ol,避免命中页面里另一个 display:none 的废弃 dl。
+        """
+        suffix = "hour" if kind == "hour" else "minute"
+        return (
+            "const dl = (" + WeixinGzhPlatform._find_visible_picker_dl_js() + ")();"
+            " const items = dl ? dl.querySelectorAll('.weui-desktop-picker__time__" + suffix + " li') : [];"
+        )
+
+    @staticmethod
+    async def _click_time_wheel_item(page, kind: str, value: str) -> bool:
+        """点击时分滚轮里目标值的 li(在可见 dl 内部),并校验是否真的选中。
+
+        kind: 'hour' 或 'minute'。
+        - 先用 JS ``li.click()`` 选值(同步、便于处理带空白的文本);
+        - 点击后检查该 li 是否获得 ``weui-desktop-picker__selected``;
+        - 若 JS click 未生效,改用真实鼠标点击该 li 的中心坐标再校验一次。
+        """
+        body = WeixinGzhPlatform._wheel_items_js_body(kind)
+
+        # 先探测滚轮里 li 数量、目标值是否存在、是否被禁用
+        info = await page.evaluate(
+            "(val) => { " + body +
+            " let total=items.length, disabled=0, found=false, found_disabled=false;"
+            " for (const li of items) {"
+            "  if (li.classList.contains('weui-desktop-picker__disabled')) { disabled++; if ((li.textContent||'').trim()===val) found_disabled=true; continue; }"
+            "  if ((li.textContent||'').trim()===val) found=true;"
+            " }"
+            " return {total, disabled, found, found_disabled}; }",
+            value,
+        )
+        logger.info("[阶段②][时间] %s 目标值 %s 探测: %s", kind, value, info)
+        if not info or not info.get("found"):
+            return False
+
+        # 尝试 1: JS 直接 click 匹配的 li
+        await page.evaluate(
+            "(val) => { " + body +
+            " for (const li of items) {"
+            "  if (li.classList.contains('weui-desktop-picker__disabled')) continue;"
+            "  if ((li.textContent||'').trim()===val) { li.click(); }"
+            " } }",
+            value,
+        )
+        await asyncio.sleep(0.3)
+        sel1 = await WeixinGzhPlatform._is_wheel_item_selected(page, kind, value)
+        logger.info("[阶段②][时间] %s JS click 后 selected=%s", kind, sel1)
+        if sel1:
+            return True
+
+        # 尝试 2: 真实鼠标点击该 li 的中心坐标(仅在面板展开、li 可见时有效)
+        center = await page.evaluate(
+            "(val) => { " + body +
+            " for (const li of items) {"
+            "  if (li.classList.contains('weui-desktop-picker__disabled')) continue;"
+            "  if ((li.textContent||'').trim()!==val) continue;"
+            "  const r = li.getBoundingClientRect();"
+            "  if (r.width===0 && r.height===0) return null;"
+            "  return {x: r.left + r.width/2, y: r.top + r.height/2};"
+            " } return null; }",
+            value,
+        )
+        if center:
+            logger.info("[阶段②][时间] %s 鼠标兜底点击坐标 %s", kind, center)
+            try:
+                await page.mouse.click(center["x"], center["y"])
+                await asyncio.sleep(0.3)
+            except Exception as e:
+                logger.warning("[阶段②][时间] %s 鼠标点击异常: %s", kind, str(e)[:100])
+        else:
+            logger.warning("[阶段②][时间] %s 无法取到 li 中心坐标(可能未展开)", kind)
+        sel2 = await WeixinGzhPlatform._is_wheel_item_selected(page, kind, value)
+        logger.info("[阶段②][时间] %s 鼠标 click 后 selected=%s", kind, sel2)
+        return sel2
+
+    @staticmethod
+    async def _is_wheel_item_selected(page, kind: str, value: str) -> bool:
+        """检查目标值的 li(在可见 dl 内部)是否已获得 ``weui-desktop-picker__selected``。"""
+        body = WeixinGzhPlatform._wheel_items_js_body(kind)
+        return await page.evaluate(
+            "(val) => { " + body +
+            " for (const li of items) {"
+            "  if ((li.textContent||'').trim()===val) {"
+            "   return li.classList.contains('weui-desktop-picker__selected');"
+            "  }"
+            " } return false; }",
+            value,
+        )
+
+    @staticmethod
+    async def _wait_for_home(page, timeout_s: int = 120):
+        """等待页面跳转到公众号首页(发表成功信号)。"""
+        deadline = asyncio.get_event_loop().time() + timeout_s
+        while asyncio.get_event_loop().time() < deadline:
+            try:
+                url = page.url or ""
+                if _HOME_PATH in url and "token=" in url:
+                    logger.info("[阶段②] 已跳转首页,发表成功")
+                    return
+            except Exception:
+                pass
+            await asyncio.sleep(2)
+        logger.warning("[阶段②] %ds 内未跳转首页(发表可能仍在处理)", timeout_s)

--- a/backend/util/video_limits.py
+++ b/backend/util/video_limits.py
@@ -22,7 +22,9 @@ VIDEO_LIMITS: dict[str, dict] = {
     # CSDN: 视频大小≤2G, 时长不限, 标题≤30字
     "csdn":          {"min_duration": 0,    "max_duration": math.inf,         "max_size": 2 * 1024**3,  "max_title_length": 30},
     # VIVO: 视频大小≤2G, 时长≤90min(5400s), 用「视频描述」非标题故不限标题
-    "vivo":          {"min_duration": 0,    "max_duration": 5400,             "max_size": 2 * 1024**3,  "max_title_length": math.inf},
+    "vivo":          {"min_duration": 0, "max_duration": 5400,             "max_size": 2 * 1024**3,  "max_title_length": math.inf},
+    # 微信公众号: 视频时长<1h, 标题≤64字, 描述(含#标签)≤300字
+    "weixin_gzh":    {"min_duration": 0, "max_duration": 3600,             "max_size": math.inf,     "max_title_length": 64, "max_desc_length": 300},
 }
 
 

--- a/frontend/src/api/weixin_gzh.js
+++ b/frontend/src/api/weixin_gzh.js
@@ -1,0 +1,9 @@
+import { http } from '@/utils/request'
+
+// 微信公众号创作者平台相关 API(后端 blueprint: backend/blueprints/weixin_gzh_bp.py)
+export const weixinGzhApi = {
+  // 获取账号的视频合集列表(后端 CloakBrowser 打开合集管理页→点视频合集 tab→解析表格 DOM)
+  getCollections(accountId) {
+    return http.get(`/api/weixin_gzh/collections?account_id=${accountId}`)
+  },
+}

--- a/frontend/src/config/platforms.js
+++ b/frontend/src/config/platforms.js
@@ -658,8 +658,21 @@ export const PLATFORMS = {
     bgColor: 'rgba(7, 193, 96, 0.15)',
     cssClass: 'weixin_gzh',
     creatorUrl: 'https://mp.weixin.qq.com/',
-    settingsFields: [],
-    defaultSettings: { title: '', description: '', scheduleTime: '' },
+    settingsFields: [
+      { key: 'isOriginal', label: '原创声明', type: 'radio', options: [{ label: '原创', value: true }, { label: '非原创', value: false }] },
+      { key: 'gzhClaimSource', label: '创作来源', type: 'select',
+        placeholder: '请选择创作来源（可选）',
+        options: [
+          { label: '内容由AI生成', value: '内容由AI生成' },
+          { label: '内容剧情演绎，仅供娱乐', value: '内容剧情演绎，仅供娱乐' },
+          { label: '个人观点，仅供参考', value: '个人观点，仅供参考' },
+          { label: '健康医疗分享，仅供参考', value: '健康医疗分享，仅供参考' },
+          { label: '投资观点，仅供参考', value: '投资观点，仅供参考' },
+          { label: '无需声明', value: '无需声明' },
+        ] },
+      { key: 'scheduleTime', label: '定时发布', type: 'datetime', placeholder: '选择时间（最近7天，需大于当前1小时）' },
+    ],
+    defaultSettings: { title: '', description: '', isOriginal: false, gzhClaimSource: '', gzhCollectionName: '', gzhCollectionData: null, scheduleTime: '', videoFormat: '' },
   },
 }
 

--- a/frontend/src/views/PublishCenter.vue
+++ b/frontend/src/views/PublishCenter.vue
@@ -327,6 +327,23 @@
               </div>
             </template>
 
+            <!-- 微信公众号合集(账号级,选中账号后才显示) -->
+            <template v-if="selectedPlatform === 'weixin_gzh' && selectedAccountId">
+              <div class="setting-card" :style="{ borderColor: currentPlatformConfig.color + '26', background: currentPlatformConfig.color + '0a' }">
+                <div class="setting-label" :style="{ color: currentPlatformConfig.color }">加入合集</div>
+                <RemoteSearchSelect
+                  v-model="form.gzhCollectionName"
+                  :data="form.gzhCollectionData"
+                  :fetcher="fetchGzhCollections"
+                  :field-map="{ label: 'name' }"
+                  search-mode="frontend"
+                  empty-behavior="load-all"
+                  placeholder="选择合集"
+                  @change="handleGzhCollectionChange"
+                />
+              </div>
+            </template>
+
             <!-- settingsFields（排除已在通用字段渲染的） -->
             <template v-for="field in currentPlatformConfig.settingsFields" :key="field.key">
               <template v-if="field.key !== 'title' && field.key !== 'description' && field.key !== 'videoFormat'">
@@ -629,6 +646,7 @@ import { douyinImageApi } from '@/api/douyinImage'
 import { alipayApi } from '@/api/alipay'
 import { toutiaoApi } from '@/api/toutiao'
 import { weiboApi } from '@/api/weibo'
+import { weixinGzhApi } from '@/api/weixin_gzh'
 import { useAutoSave } from '@/composables/useAutoSave'
 import { useBatchSetApply } from '@/composables/useBatchSetApply'
 import { frameApi } from '@/api/frame'
@@ -885,6 +903,11 @@ function mergeConfig(common, platformDefault, platformOv, accountOv) {
     vivoDeclaration: accountOv?.vivoDeclaration ?? platformOv?.vivoDeclaration ?? platformDefault?.vivoDeclaration ?? '',
     vivoPrivacy: accountOv?.vivoPrivacy ?? platformOv?.vivoPrivacy ?? platformDefault?.vivoPrivacy ?? '公开',
     vivoDownloadPermission: accountOv?.vivoDownloadPermission ?? platformOv?.vivoDownloadPermission ?? platformDefault?.vivoDownloadPermission ?? '允许',
+    // 微信公众号合集(账号级)
+    gzhCollectionName: accountOv?.gzhCollectionName ?? platformOv?.gzhCollectionName ?? platformDefault?.gzhCollectionName ?? '',
+    gzhCollectionData: accountOv?.gzhCollectionData ?? platformOv?.gzhCollectionData ?? platformDefault?.gzhCollectionData ?? null,
+    // 微信公众号创作来源(平台级)
+    gzhClaimSource: accountOv?.gzhClaimSource ?? platformOv?.gzhClaimSource ?? platformDefault?.gzhClaimSource ?? '',
   }
 }
 
@@ -954,6 +977,7 @@ const platformConfigs = reactive({
   vivo: { title: '', description: '', vivoLocationName: '', vivoLocationData: null,
     vivoDistribution: false, vivoDeclaration: '', vivoPrivacy: '公开',
     vivoDownloadPermission: '允许', scheduleTime: '', tags: [] },
+  weixin_gzh: { title: '', description: '', isOriginal: false, gzhClaimSource: '', gzhCollectionName: '', gzhCollectionData: null, scheduleTime: '', tags: [] },
 })
 
 const accountOverrides = reactive({})
@@ -1322,6 +1346,25 @@ function handleWeiboCollectionChange(col) {
     form.weiboCollectionData = col
   } else {
     form.weiboCollectionData = null
+  }
+}
+
+// 微信公众号合集 —— RemoteSearchSelect 数据源(后端一次返回全量,前端过滤)
+async function fetchGzhCollections(keyword) {
+  const resp = await weixinGzhApi.getCollections(selectedAccountId.value)
+  const all = resp.data?.list || []
+  const kw = keyword?.trim().toLowerCase()
+  return {
+    list: kw ? all.filter(c => c.name?.toLowerCase().includes(kw)) : all
+  }
+}
+
+// 微信公众号合集选择回调
+function handleGzhCollectionChange(col) {
+  if (col) {
+    form.gzhCollectionData = col
+  } else {
+    form.gzhCollectionData = null
   }
 }
 
@@ -2441,6 +2484,10 @@ async function publishAll() {
         vivoDeclaration: merged.vivoDeclaration || '',
         vivoPrivacy: merged.vivoPrivacy || '公开',
         vivoDownloadPermission: merged.vivoDownloadPermission || '允许',
+        // 微信公众号特有参数(原创声明/创作来源/合集)
+        isOriginal: merged.isOriginal ?? false,
+        gzhClaimSource: merged.gzhClaimSource || '',
+        gzhCollectionName: merged.gzhCollectionName || '',
         hotspot: merged.hotspotId || '',
         tag_type: merged.tagType || '',
         tag_value: merged.tagValue || '',


### PR DESCRIPTION
后端:
- 注册 weixin_gzh_bp 蓝图; postVideo/postVideoBatch 透传公众号特有参数 (原创声明/合集/创作来源)
- 新增 video_limits.weixin_gzh 限制(时长<1h, 标题<=64, 描述<=300)

平台实现 (impl/weixin_gzh/platform.py):
- 两阶段发布: 素材上传页(视频/封面/标题/原创/服务规则/保存并发表) → 发布编辑页(标题/描述/合集/创作来源/发表或定时)
- 定时发布时分选择修复: 页面常驻两个 dl.weui-desktop-picker__time (其一 display:none 废弃容器), 旧代码 querySelector/locator.first 永远命中 隐藏的那个导致选不上时分。改为所有时分操作基于「可见 dl」(getComputedStyle display!=='none'), 并对展开/选中做校验。

前端:
- platforms.js: 公众号 settingsFields 增加原创声明/创作来源/定时发布
- 新增 api/weixin_gzh.js; PublishCenter.vue 接入公众号发布