### PR TITLE
feat(weixin_gzh): 新增图集(贴图)发布 + 修复图集定时发布 scheduleTime 合并

### DIFF
--- a/backend/blueprints/image_publish_bp.py
+++ b/backend/blueprints/image_publish_bp.py
@@ -176,6 +176,7 @@ def publish_images():
                 'weibo': 11, '微博': 11,   # 新增
                 'alipay': 12, '支付宝': 12,  # 图集发布
                 'vivo': 16, 'VIVO': 16,
+                'weixin_gzh': 17, '微信公众号': 17,  # 公众号贴图
             }
             platform_id = platform_map.get(platform_type)
             if not platform_id:
@@ -222,6 +223,9 @@ def publish_images():
                 author_statement=config.get('author_statement', '') or config.get('authorStatement', ''),
                 music_id=config.get('music_id', ''),
                 music_title=config.get('music_title', ''),
+                # 微信公众号图集特有字段(视频发布侧用的 snake_case 此处补 camelCase 读取)
+                gzh_collection_name=config.get('gzhCollectionName', '') or config.get('gzh_collection_name', ''),
+                gzh_claim_source=config.get('gzhClaimSource', '') or config.get('gzh_claim_source', ''),
                 dry_run=dry_run,
             )
             if asyncio.iscoroutinefunction(publish_fn):

--- a/backend/blueprints/weixin_gzh_bp.py
+++ b/backend/blueprints/weixin_gzh_bp.py
@@ -80,22 +80,27 @@ def run_async(coro):
 
 @weixin_gzh_bp.route('/collections', methods=['GET'])
 def list_collections():
-    """获取账号的视频合集列表。
+    """获取账号的合集列表(视频合集 / 贴图合集)。
 
     Query params:
         account_id: 账号 id(用于取 cookie)
+        collection_type: 合集类型 tab 文案,默认「视频合集」;
+                         图集传「贴图合集」。
+                         若页面上找不到该 tab,说明账号无此类型合集,
+                         返回空列表(不报错)。
 
     流程:
         1. 用账号 cookie 打开公众号首页,等 cookie 触发跳转,解析 token
         2. 用 token 打开合集管理页(appmsgalbummgr)
-        3. 点「视频合集」tab
+        3. 点对应 tab(视频合集/贴图合集);找不到则返回空
         4. 解析表格 tbody tr 的 .album-title 文本(合集名)
 
     Returns:
         {"code": 200, "data": {"list": [{"name": "..."}], "total": N}}
     """
     account_id = request.args.get('account_id')
-    logger.info(f"[合集列表] 收到请求: account_id={account_id}")
+    collection_type = request.args.get('collection_type') or '视频合集'
+    logger.info(f"[合集列表] 收到请求: account_id={account_id}, collection_type={collection_type}")
 
     try:
         cookie_file = _get_account_cookie_file(account_id)
@@ -103,11 +108,11 @@ def list_collections():
             logger.warning(f"[合集列表] 账号不存在: {account_id}")
             return jsonify({"code": 404, "msg": "没有可用的微信公众号账号"}), 404
 
-        result = run_async(_fetch_collections_via_browser(cookie_file))
+        result = run_async(_fetch_collections_via_browser(cookie_file, collection_type))
 
         if result.get("success"):
             data = result.get("data", {})
-            logger.info(f"[合集列表] 成功,共 {data.get('total', 0)} 个合集")
+            logger.info(f"[合集列表] 成功[{collection_type}],共 {data.get('total', 0)} 个合集")
             return jsonify({"code": 200, "data": data})
         else:
             logger.error(f"[合集列表] 失败: {result.get('error')}")
@@ -119,11 +124,11 @@ def list_collections():
         return jsonify({"code": 500, "msg": str(e)}), 500
 
 
-async def _fetch_collections_via_browser(cookie_file: str) -> dict:
-    """打开公众号合集管理页,点「视频合集」tab,解析表格 DOM 拿合集列表。
+async def _fetch_collections_via_browser(cookie_file: str, collection_type: str = '视频合集') -> dict:
+    """打开公众号合集管理页,点指定类型 tab,解析表格 DOM 拿合集列表。
 
     DOM 结构(需求文档):
-      tab: <li class="weui-desktop-tag">视频合集</li>
+      tab: <li class="weui-desktop-tag">视频合集/贴图合集</li>
       表格: table.weui-desktop-table > tbody > tr > td.album-title
         合集名在 .album-title-tips 文本里
 
@@ -165,14 +170,20 @@ async def _fetch_collections_via_browser(cookie_file: str) -> dict:
             except Exception as e:
                 logger.info(f"[合集列表] 合集页加载(非致命): {e}")
 
-            # 3. 点「视频合集」tab
-            tag = page.locator("li.weui-desktop-tag", has_text="视频合集").first
+            # 3. 点对应类型 tab(视频合集/贴图合集)
+            #    **找不到 tab = 账号无该类型合集,直接返回空**(不报错、不继续解析)
+            tag = page.locator(
+                "li.weui-desktop-tag", has_text=collection_type
+            ).first
+            tag_found = False
             try:
-                await tag.wait_for(state="visible", timeout=10000)
+                await tag.wait_for(state="visible", timeout=8000)
                 await tag.click()
-                logger.info("[合集列表] 已点击「视频合集」tab")
-            except Exception as e:
-                logger.info(f"[合集列表] 未找到「视频合集」tab(可能默认已选中): {e}")
+                tag_found = True
+                logger.info(f"[合集列表] 已点击「{collection_type}」tab")
+            except Exception:
+                logger.info(f"[合集列表] 未找到「{collection_type}」tab → 账号无该类型合集,返回空")
+                return {"success": True, "data": {"list": [], "total": 0}}
             await asyncio.sleep(1.5)
 
             # 4. 解析表格 tbody tr 的 .album-title 文本
@@ -184,8 +195,8 @@ async def _fetch_collections_via_browser(cookie_file: str) -> dict:
                     break
                 await asyncio.sleep(0.5)
             if not ready:
-                # 没有合集也是正常情况
-                logger.info("[合集列表] 表格中未发现合集(账号可能无合集)")
+                # tab 找到了但表格空 = 该类型下无合集
+                logger.info(f"[合集列表] 「{collection_type}」tab 下无合集")
                 return {"success": True, "data": {"list": [], "total": 0}}
 
             count = await title_els.count()

--- a/backend/impl/weixin_gzh/platform.py
+++ b/backend/impl/weixin_gzh/platform.py
@@ -1132,26 +1132,54 @@ class WeixinGzhPlatform(BasePlatform):
     # ------------------------------------------------------------------
 
     @staticmethod
-    async def _fill_publish_title(page, title: str):
-        """发布编辑页标题:``#title textarea.js_title``,≤64 字。
+    async def _fill_publish_title(page, title: str, max_len: int = 64):
+        """发布编辑页标题。
 
-        DOM(文档): 该 textarea 上方有 ProseMirror 覆盖层,直接 fill 即可触发。
+        - 视频版: ``#title textarea.js_title`` 可见,直接 fill。
+        - 图集版(贴图): 同 id 的 textarea 被 ``visibility:hidden`` 隐藏,真正可编辑的是
+          ProseMirror 覆盖层 ``.title-editor-overlay .ProseMirror``(contenteditable)。
+          检测到 textarea 不可见时,改用 press_sequentially 往 ProseMirror 输入。
+
+        max_len 默认 64(视频),图集传 20。
         """
-        title_input = page.locator("#title.js_title").first
-        if await title_input.count() == 0:
-            title_input = page.locator("textarea.js_title").first
-        await title_input.wait_for(state="visible", timeout=15000)
-        await title_input.fill((title or "")[:64])
-        logger.info("[阶段②] 发布页标题已填写(%d 字)", len((title or "")[:64]))
+        text = (title or "")[:max_len]
+        title_textarea = page.locator("#title.js_title").first
+        if await title_textarea.count() == 0:
+            title_textarea = page.locator("textarea.js_title").first
+
+        # 图集版: textarea 隐藏 → 用 ProseMirror 覆盖层(contenteditable)
+        textarea_visible = False
+        try:
+            textarea_visible = await title_textarea.is_visible()
+        except Exception:
+            textarea_visible = False
+
+        if textarea_visible:
+            # 视频版: 直接 fill textarea
+            await title_textarea.fill(text)
+            logger.info("[阶段②] 发布页标题已填写(%d 字, textarea fill)", len(text))
+            return
+
+        # 图集版: 找 ProseMirror 覆盖层,press_sequentially 逐字符输入
+        pm = page.locator(".title-editor-overlay .ProseMirror").first
+        await pm.wait_for(state="visible", timeout=10000)
+        try:
+            await pm.click()
+        except Exception:
+            pass
+        await pm.press_sequentially(text, delay=30)
+        await asyncio.sleep(0.5)
+        logger.info("[阶段②] 发布页标题已填写(%d 字, ProseMirror)", len(text))
 
     @staticmethod
-    async def _fill_description(page, desc: str, title: str, tags: list):
-        """填写视频描述(contenteditable ProseMirror),含 # 标签,≤300 字。
+    async def _fill_description(page, desc: str, title: str, tags: list, max_len: int = 300):
+        """填写描述(contenteditable ProseMirror),含 # 标签。
 
         DOM(文档): ``#guide_words_main .ProseMirror``(contenteditable)
         desc 为空时回落 title;tags 拼成 ``#话题`` 追加。
         按 CLAUDE.md: contenteditable 用 press_sequentially 逐字符输入,
         比剪贴板粘贴/keyboard.type 更可靠地触发 React onChange。
+        max_len 默认 300(视频),图集传 1000。
         """
         editor = page.locator("#guide_words_main .ProseMirror").first
         await editor.wait_for(state="visible", timeout=15000)
@@ -1161,8 +1189,8 @@ class WeixinGzhPlatform(BasePlatform):
         tag_parts = [f"#{t.strip()}" for t in (tags or []) if str(t).strip()]
         tag_text = " ".join(tag_parts)
         full = f"{base} {tag_text}".strip() if tag_text else base
-        # 截断到 300 字(含 # 标签,文档要求)
-        full = full[:300]
+        # 截断到 max_len 字(含 # 标签,文档要求)
+        full = full[:max_len]
         if not full:
             logger.info("[阶段②] 描述为空,跳过")
             return
@@ -1828,3 +1856,349 @@ class WeixinGzhPlatform(BasePlatform):
                 pass
             await asyncio.sleep(2)
         logger.warning("[阶段②] %ds 内未跳转首页(发表可能仍在处理)", timeout_s)
+
+    # ==================================================================
+    # publish_image — 图集(贴图)发布
+    # ==================================================================
+
+    # 贴图菜单:创作中心首页的「贴图」入口。
+    # DOM(用户文档): ``.new-creation__menu-item`` 内文字含「贴图」。
+    _IMAGE_MENU_TEXT = "贴图"
+    # 图集标题/描述上限(与视频不同:视频 64/300, 图集 20/1000)
+    _IMAGE_TITLE_MAX = 20
+    _IMAGE_DESC_MAX = 1000
+
+    def publish_image(self, **kwargs) -> bool:
+        """发布图集(贴图)到公众号(同步入口)。
+
+        流程: 创作中心首页点「贴图」→ 新 tab(appmsg_edit_v2 type=77)
+        → 上传多图 → 复用 video 的标题/描述/合集/创作来源/发表 helpers。
+
+        入口仅做 dry-run 早返回 + 调 _upload_all_images。
+        """
+        dry_run = kwargs.get("dry_run", False)
+        if dry_run:
+            logger.info("[发布图集] dry-run 模式, 跳过实际发布 (publish_image)")
+            return True
+        asyncio.run(self._upload_all_images(**kwargs))
+        return True
+
+    async def _upload_all_images(self, **kwargs):
+        """图集编排:**单层账号循环**(一账号一次发完所有图),非笛卡尔积。"""
+        logger.info("=" * 60)
+        logger.info("[发布图集] 开始微信公众号图集发布流程")
+        logger.info("=" * 60)
+
+        logger.info("[发布参数] 接收到的所有参数:")
+        for key, value in kwargs.items():
+            logger.info("[发布参数]   %s = %s (类型: %s)", key, value, type(value).__name__)
+
+        files = kwargs.get("files", []) or []
+        account_file = kwargs.get("account_file", []) or []
+        title = kwargs.get("title", "")
+        tags = kwargs.get("tags", []) or []
+        desc = kwargs.get("desc", "") or ""
+        is_original = kwargs.get("is_original", False)
+        gzh_collection_name = kwargs.get("gzh_collection_name", "") or ""
+        gzh_claim_source = kwargs.get("gzh_claim_source", "") or ""
+        enable_timer = kwargs.get("enableTimer", False)
+        schedule_time_str = kwargs.get("schedule_time_str", "")
+
+        # 忽略字段(公众号图集不支持)
+        _ = kwargs.get("cover_path")  # noqa
+        _ = kwargs.get("music_name")  # noqa
+        _ = kwargs.get("ai_content")  # noqa
+
+        logger.info("[发布参数] 标题: %s", title)
+        logger.info("[发布参数] 图片数量: %d", len(files))
+        logger.info("[发布参数] 标签: %s", tags)
+        logger.info("[发布参数] 描述: %s", desc[:50] if desc else "无")
+        logger.info("[发布参数] 账号数量: %d", len(account_file))
+        logger.info("[发布参数] 原创: %s", is_original)
+        logger.info("[发布参数] 合集: %s", gzh_collection_name or "无")
+        logger.info("[发布参数] 创作来源: %s", gzh_claim_source or "无")
+
+        file_path_list = [str(f) for f in files]
+        account_paths = [str(Path(BASE_DIR / "cookiesFile") / f) for f in account_file]
+
+        for cookie_index, cookie_path in enumerate(account_paths):
+            cookie_name = Path(cookie_path).name
+            nick = get_account_name_by_cookie_file(cookie_name)
+            with bind_account_name(nick or "-"):
+                logger.info("[发布进度] 发布到第 %d/%d 个账号 (%s)", cookie_index + 1, len(account_paths), nick or "未知")
+                await self._upload_one_image(
+                    title=title,
+                    file_path_list=file_path_list,
+                    tags=tags,
+                    account_file=cookie_path,
+                    desc=desc,
+                    is_original=is_original,
+                    gzh_collection_name=gzh_collection_name,
+                    gzh_claim_source=gzh_claim_source,
+                    enable_timer=enable_timer,
+                    schedule_time_str=schedule_time_str,
+                )
+
+        logger.info("=" * 60)
+        logger.info("[发布图集] 图集发布流程完成!")
+        logger.info("=" * 60)
+
+    async def _upload_one_image(
+        self,
+        title: str,
+        file_path_list: list,
+        tags: list,
+        account_file: str,
+        desc: str = "",
+        is_original: bool = False,
+        gzh_collection_name: str = "",
+        gzh_claim_source: str = "",
+        enable_timer: bool = False,
+        schedule_time_str: str = "",
+    ):
+        """单账号图集发布完整流程。
+
+        与 video 的区别:图集只有一阶段 —— 创作中心首页点「贴图」直接进
+        appmsg_edit_v2(type=77)编辑页,在该页上传图片 + 填写 + 发表。
+        video 的素材上传页(videomsg_edit)→保存并发表→新 tab 两阶段,
+        图集直接进编辑页,更简单。
+
+        复用 video 的阶段②helpers(标题/描述/合集/创作来源/发表/定时)。
+        """
+        logger.info("[上传图集] 开始上传图集 (%d 张图片)", len(file_path_list))
+        browser = await self.create_browser(headless=False)
+        try:
+            context = await self.create_context(
+                browser,
+                storage_state=account_file,
+                user_agent=(
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/127.0.4324.150 Safari/537.36"
+                ),
+            )
+            try:
+                page = await context.new_page()
+
+                # 1. 解析 token + 进创作中心首页
+                token = await self._resolve_token(page)
+                if not token:
+                    raise RuntimeError("[发布图集] 未能获取 token,cookie 可能已失效")
+                logger.info("[发布图集] 获取到 token: %s", token)
+                home_url = self._build_home_url(token)
+                logger.info("[发布图集] 打开创作中心首页: %s", home_url)
+                await page.goto(home_url, wait_until="domcontentloaded", timeout=30000)
+                await asyncio.sleep(3)
+
+                # 2. 点击「贴图」菜单 → 捕获新 tab
+                page2 = await self._click_image_menu(page, context)
+                logger.info("[发布图集] 贴图编辑页已打开: %s", page2.url)
+                await page2.wait_for_load_state("domcontentloaded", timeout=30000)
+                await asyncio.sleep(2)
+
+                # 3. 上传多图
+                logger.info("[发布图集] 开始上传 %d 张图片...", len(file_path_list))
+                await self._upload_images(page2, file_path_list)
+                logger.info("[发布图集] 图片上传完成!")
+
+                # 4. 标题(图集≤20字)
+                logger.info("[发布图集] 填写标题: %s", title)
+                await self._fill_publish_title(page2, title, max_len=self._IMAGE_TITLE_MAX)
+
+                # 5. 描述(图集≤1000字)
+                logger.info("[发布图集] 填写描述/标签...")
+                await self._fill_description(
+                    page2, desc, title, tags, max_len=self._IMAGE_DESC_MAX,
+                )
+
+                # 6. 合集(可选)
+                if gzh_collection_name:
+                    logger.info("[发布图集] 选择合集: %s", gzh_collection_name)
+                    await self._set_collection(page2, gzh_collection_name)
+                else:
+                    logger.info("[发布图集] 未选择合集,跳过")
+
+                # 7. 创作来源(可选)
+                if gzh_claim_source:
+                    logger.info("[发布图集] 设置创作来源: %s", gzh_claim_source)
+                    await self._set_claim_source(page2, gzh_claim_source)
+                else:
+                    logger.info("[发布图集] 未设置创作来源,跳过")
+
+                # 8. 发表(立即/定时,与视频完全一致)
+                if enable_timer and schedule_time_str:
+                    publish_dt = self._build_publish_datetime(schedule_time_str, 1)
+                    if publish_dt and not (isinstance(publish_dt, int) and publish_dt == 0):
+                        logger.info("[发布图集] 定时发布: %s", publish_dt)
+                        await self._publish_scheduled(page2, publish_dt)
+                    else:
+                        logger.info("[发布图集] 定时时间解析失败,改为立即发表")
+                        await self._publish_immediate(page2)
+                else:
+                    logger.info("[发布图集] 立即发表...")
+                    await self._publish_immediate(page2)
+
+                logger.info("[发布图集] 图集发布成功!")
+
+                # 保存 cookie
+                await context.storage_state(path=account_file)
+                logger.info("[发布图集] Cookie 状态已更新")
+                await asyncio.sleep(2)
+            finally:
+                await context.close()
+        finally:
+            await self.close_browser(browser, is_close_by_code=True)
+
+    async def _click_image_menu(self, page, context):
+        """点击创作中心首页的「贴图」菜单,返回打开的新 tab page。
+
+        DOM(用户文档): ``.new-creation__menu-item`` 内 ``.new-creation__menu-title``
+        文字为「贴图」。点击后打开新 tab(appmsg_edit_v2 type=77 createType=8)。
+        用 context.on("page") 捕获新 tab,过滤 about:blank。
+        """
+        new_page_holder = {"page": None}
+
+        def _on_new_page(new_page):
+            try:
+                url = new_page.url or ""
+            except Exception:
+                url = ""
+            logger.info("[发布图集] 检测到新 tab: %s", url or "(about:blank)")
+            if "appmsg_edit" in url:
+                new_page_holder["page"] = new_page
+
+        context.on("page", _on_new_page)
+        try:
+            # 找「贴图」菜单项(用文案定位,避免 svg 路径匹配)
+            # 定位含「贴图」文案的菜单标题元素,再点它(或其父级 menu-item)
+            menu_title = page.locator(
+                ".new-creation__menu-title",
+                has_text=self._IMAGE_MENU_TEXT,
+            ).first
+            await menu_title.wait_for(state="visible", timeout=15000)
+            # 点击 menu-title 的父级 menu-item(整个卡片可点)
+            menu = menu_title.locator("xpath=ancestor::div[contains(@class,'new-creation__menu-item')][1]")
+            await menu.wait_for(state="visible", timeout=15000)
+            await menu.click()
+            logger.info("[发布图集] 已点击「贴图」菜单,等待新 tab...")
+
+            # 轮询等待目标新 tab 导航到 appmsg_edit
+            deadline = asyncio.get_event_loop().time() + 30
+            target_page = None
+            while asyncio.get_event_loop().time() < deadline:
+                if new_page_holder["page"] is not None:
+                    target_page = new_page_holder["page"]
+                    break
+                # 兜底:从 context.pages 找已导航到 appmsg_edit 的 tab
+                for p in context.pages:
+                    try:
+                        if p is page:
+                            continue
+                        if "appmsg_edit" in (p.url or ""):
+                            target_page = p
+                            new_page_holder["page"] = p
+                            break
+                    except Exception:
+                        continue
+                if target_page is not None:
+                    break
+                await asyncio.sleep(1)
+
+            if target_page is None:
+                raise RuntimeError("[发布图集] 点击「贴图」后未捕获到编辑页新 tab")
+            try:
+                await target_page.wait_for_url("**/appmsg_edit*", timeout=30000)
+            except Exception as e:
+                logger.info("[发布图集] 新 tab URL 等待(非致命): %s, 当前: %s", e, target_page.url)
+            await target_page.bring_to_front()
+            return target_page
+        finally:
+            context.remove_listener("page", _on_new_page)
+
+    @staticmethod
+    async def _upload_images(page, file_path_list: list):
+        """上传多张图片(一次性 set_input_files)。
+
+        贴图编辑页(appmsg_edit_v2 type=77)的图片上传 input(DOM 实测):
+          ``.js_upload_btn_container input[type='file'][accept*='image']``
+          (带 multiple, style display:none 隐藏但 set_input_files 仍可用)
+
+        一次性把所有图片路径传进去,再等待上传完成(轮询图片预览项数量)。
+        """
+        if not file_path_list:
+            logger.warning("[发布图集] 无图片可上传")
+            return
+
+        # 找图片上传 input —— 多选择器兜底
+        input_selectors = [
+            ".js_upload_btn_container input[type='file']",
+            "input[type='file'][accept*='image']",
+            "input[type='file'][multiple]",
+        ]
+        img_input = None
+        for sel in input_selectors:
+            loc = page.locator(sel).first
+            try:
+                await loc.wait_for(state="attached", timeout=8000)
+                img_input = loc
+                logger.info("[发布图集] 找到图片上传 input, 选择器: %s", sel)
+                break
+            except Exception:
+                continue
+        if img_input is None:
+            raise RuntimeError("[发布图集] 未找到图片上传 input")
+
+        await img_input.set_input_files(file_path_list)
+        logger.info("[发布图集] 已提交 %d 张图片,等待上传...", len(file_path_list))
+
+        # 等待上传完成:已上传的图片项数量达到预期(轮询,最多 5 分钟)
+        # 贴图编辑页每张图会生成一个预览项(li/div 含 img 或上传进度条)
+        target_count = len(file_path_list)
+        deadline = asyncio.get_event_loop().time() + 300
+        last_info = ""
+        while asyncio.get_event_loop().time() < deadline:
+            info = await page.evaluate(
+                """(target) => {
+                    // 已上传图片的预览项(公众号贴图页多种可能结构)
+                    // 1. 含已上传缩略图的列表项
+                    // 2. 上传进度项(上传中)/ 完成项
+                    const sels = [
+                        '.appmsg_edit_item img',
+                        '.js_appmsg_list img',
+                        '.weui-desktop-card .appmsg_edit_item',
+                        'img[data-src]',
+                        '.upload_item',
+                    ];
+                    let best = 0;
+                    for (const sel of sels) {
+                        const els = document.querySelectorAll(sel);
+                        let visible = 0;
+                        for (const el of els) {
+                            const r = el.getBoundingClientRect();
+                            if (r.width > 0 && r.height > 0) visible++;
+                        }
+                        if (visible > best) best = visible;
+                    }
+                    // 上传中检测:是否有进度条/上传中文案
+                    const uploading = document.querySelectorAll(
+                        '.weui-desktop-upload__file__progress, [class*="upload"][class*="progress"]'
+                    ).length;
+                    return {best, uploading, target};
+                }""",
+                target_count,
+            )
+            cur = f"已上传预览={info.get('best', 0)}/目标={target_count} 上传中={info.get('uploading', 0)}"
+            if cur != last_info:
+                logger.info("[发布图集] 上传进度: %s", cur)
+                last_info = cur
+            # 完成: 预览数达到目标;或(有预览且无上传中=上传已结束)
+            best = info.get("best", 0)
+            uploading = info.get("uploading", 0)
+            if best >= target_count:
+                logger.info("[发布图集] 全部 %d 张图片已上传", target_count)
+                return
+            if best > 0 and uploading == 0:
+                logger.info("[发布图集] 上传已结束(预览 %d 张,目标 %d)", best, target_count)
+                return
+            await asyncio.sleep(3)
+        logger.warning("[发布图集] 图片上传等待超时(可能部分未完成),继续后续操作")

--- a/frontend/src/api/weixin_gzh.js
+++ b/frontend/src/api/weixin_gzh.js
@@ -2,8 +2,10 @@ import { http } from '@/utils/request'
 
 // 微信公众号创作者平台相关 API(后端 blueprint: backend/blueprints/weixin_gzh_bp.py)
 export const weixinGzhApi = {
-  // 获取账号的视频合集列表(后端 CloakBrowser 打开合集管理页→点视频合集 tab→解析表格 DOM)
-  getCollections(accountId) {
-    return http.get(`/api/weixin_gzh/collections?account_id=${accountId}`)
+  // 获取账号的合集列表(视频合集/贴图合集,由 collectionType 决定)
+  // 后端: CloakBrowser 打开合集管理页→点对应 tab→解析表格 DOM
+  //      找不到该类型 tab = 账号无此类型合集,返回空列表
+  getCollections(accountId, collectionType = '视频合集') {
+    return http.get(`/api/weixin_gzh/collections?account_id=${accountId}&collection_type=${encodeURIComponent(collectionType)}`)
   },
 }

--- a/frontend/src/components/weixin_gzh/ImagePublishPanel.vue
+++ b/frontend/src/components/weixin_gzh/ImagePublishPanel.vue
@@ -1,0 +1,229 @@
+<template>
+  <div class="weixin-gzh-image-publish-panel">
+    <div v-if="accountId && hasAccountOverride(accountId)" style="margin-bottom: 12px;">
+      <el-button size="small" @click="resetOverride">恢复为渠道默认</el-button>
+    </div>
+
+    <div class="setting-card" style="grid-column: 1 / -1">
+      <div class="setting-label">标题 <span class="required">*</span></div>
+      <el-input v-model="form.title" placeholder="请输入标题" maxlength="20" show-word-limit :disabled="disabled" />
+    </div>
+
+    <div class="setting-card" style="grid-column: 1 / -1">
+      <div class="setting-label">描述</div>
+      <el-input v-model="form.description" type="textarea" :rows="5" placeholder="请输入描述..." maxlength="1000" show-word-limit :disabled="disabled" />
+    </div>
+
+    <div class="setting-card" style="grid-column: 1 / -1">
+      <div class="setting-label">标签</div>
+      <div class="setting-hint">输入话题内容,按回车确认(发布时拼成 #话题1 #话题2)</div>
+      <el-input v-model="tagInput" placeholder="输入话题内容,按回车添加" @keyup.enter="addTag" clearable :disabled="disabled" />
+      <div v-if="form.tags && form.tags.length > 0" class="tags-list">
+        <el-tag v-for="(tag, index) in form.tags" :key="index" closable @close="removeTag(index)" size="small" :disable-transitions="false">#{{ tag }}</el-tag>
+      </div>
+    </div>
+
+    <div class="setting-card" style="grid-column: 1 / -1">
+      <div class="setting-label">创作来源</div>
+      <div class="setting-hint">可选。选择创作来源声明</div>
+      <div style="display: flex; gap: 8px; align-items: center;">
+        <el-select v-model="form.gzhClaimSource" placeholder="请选择创作来源（可选）" :disabled="disabled" clearable style="flex: 1;">
+          <el-option v-for="opt in claimSourceOptions" :key="opt.value" :label="opt.label" :value="opt.value" />
+        </el-select>
+        <el-button v-if="form.gzhClaimSource" text size="small" @click="form.gzhClaimSource = ''" :disabled="disabled">清空</el-button>
+      </div>
+    </div>
+
+    <div v-if="accountId" class="setting-card" style="grid-column: 1 / -1">
+      <div class="setting-label">加入合集</div>
+      <div class="setting-hint">可选。从贴图合集选择(无合集时为空)</div>
+      <RemoteSearchSelect
+        v-model="form.gzhCollectionName"
+        :data="form.gzhCollectionData"
+        :fetcher="fetchGzhImageCollections"
+        :field-map="{ label: 'name' }"
+        search-mode="frontend"
+        empty-behavior="load-all"
+        placeholder="选择贴图合集"
+        @change="handleCollectionChange"
+      />
+    </div>
+
+    <div class="setting-card" style="grid-column: 1 / -1">
+      <div class="setting-label">定时发布</div>
+      <div class="setting-hint">可选。最近7天,需大于当前时间至少1小时</div>
+      <el-date-picker
+        v-model="form.scheduleTime"
+        type="datetime"
+        placeholder="选择时间(不选则立即发布)"
+        format="YYYY-MM-DD HH:mm"
+        value-format="YYYY-MM-DD HH:mm:ss"
+        :disabled="disabled"
+        style="width: 100%;"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { useAccountStore } from '@/stores/account'
+import { imagePublishApi } from '@/api/imagePublish'
+import { weixinGzhApi } from '@/api/weixin_gzh'
+import { useChannelForm } from '@/composables/useChannelForm'
+import { useAutoExtractHashtags } from '@/utils/hashtag'
+import RemoteSearchSelect from '@/components/common/RemoteSearchSelect.vue'
+
+const props = defineProps({
+  accountId: { type: [Number, Object], default: null },
+  disabled: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['config-changed', 'publish-result'])
+
+const accountStore = useAccountStore()
+
+// 公众号图集默认字段(标题≤20, 描述≤1000)
+const WEIXIN_GZH_DEFAULTS = {
+  title: '',
+  description: '',
+  tags: [],
+  gzhClaimSource: '',
+  gzhCollectionName: '',
+  gzhCollectionData: null,
+  scheduleTime: '',
+}
+
+// 创作来源选项(与 platforms.js WEIXIN_GZH 一致;不含「素材来源官方媒体/网络新闻」)
+const claimSourceOptions = [
+  { label: '内容由AI生成', value: '内容由AI生成' },
+  { label: '内容剧情演绎，仅供娱乐', value: '内容剧情演绎，仅供娱乐' },
+  { label: '个人观点，仅供参考', value: '个人观点，仅供参考' },
+  { label: '健康医疗分享，仅供参考', value: '健康医疗分享，仅供参考' },
+  { label: '投资观点，仅供参考', value: '投资观点，仅供参考' },
+  { label: '无需声明', value: '无需声明' },
+]
+
+const { form, hasAccountOverride, resetOverride, publicApi } = useChannelForm(
+  WEIXIN_GZH_DEFAULTS,
+  { props, emit },
+  {
+    publishFn: async (accountId, accountName, commonData, merged, extra) => {
+      const account = accountStore.accounts.find(a => a.id === accountId)
+      if (!account) {
+        emit('publish-result', { accountName, status: 'fail', message: '账号不存在' })
+        return
+      }
+      try {
+        await imagePublishApi.publishImage({
+          image_ids: commonData.images.map(img => img.id),
+          account_configs: {
+            account_id: accountId,
+            platform: '微信公众号',
+            filePath: account.filePath,
+            title: merged.title,
+            description: merged.description,
+            tags: merged.tags || [],
+            gzhClaimSource: merged.gzhClaimSource || '',
+            gzhCollectionName: merged.gzhCollectionName || '',
+            scheduleTime: merged.scheduleTime || '',
+            cover_path: '',
+            dry_run: false,
+          },
+          batchId: extra?.batchId || '',
+          landscapeCoverMaterialId: '',
+          portraitCoverMaterialId: '',
+        })
+        emit('publish-result', { accountName, status: 'success', message: '发布成功' })
+      } catch (e) {
+        emit('publish-result', { accountName, status: 'fail', message: e.message || '发布失败' })
+      }
+    },
+    validateFn: (accountId, merged) => {
+      const errors = []
+      if (!merged.title || !merged.title.trim()) {
+        errors.push('请填写标题(≤20 字)')
+      }
+      return { valid: errors.length === 0, errors }
+    },
+  },
+)
+
+const tagInput = ref('')
+
+function addTag() {
+  const tag = tagInput.value.trim()
+  if (!tag) return
+  if (!form.tags) form.tags = []
+  if (form.tags.includes(tag)) return
+  form.tags.push(tag)
+  tagInput.value = ''
+}
+
+function removeTag(index) { form.tags.splice(index, 1) }
+
+// 贴图合集数据源(后端 type=贴图合集)
+async function fetchGzhImageCollections(keyword) {
+  const resp = await weixinGzhApi.getCollections(props.accountId, '贴图合集')
+  const all = resp.data?.list || []
+  const kw = keyword?.trim().toLowerCase()
+  return {
+    list: kw ? all.filter(c => c.name?.toLowerCase().includes(kw)) : all,
+  }
+}
+
+function handleCollectionChange(col) {
+  form.gzhCollectionData = col || null
+}
+
+// 自动提取描述中的 #xxx 到标签数组
+useAutoExtractHashtags({
+  form,
+  descKey: 'description',
+  tagKey: 'tags',
+})
+
+defineExpose(publicApi)
+</script>
+
+<style scoped lang="scss">
+@use '@/styles/variables.scss' as *;
+
+.weixin-gzh-image-publish-panel {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+  gap: 12px;
+}
+
+.setting-card {
+  border: 1px solid rgba($info-color, 0.15);
+  background: rgba($info-color, 0.04);
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.setting-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #07C160;
+  margin-bottom: 8px;
+}
+
+.required {
+  color: #f56c6c;
+}
+
+.setting-hint {
+  font-size: 12px;
+  color: #909399;
+  margin-bottom: 8px;
+  line-height: 1.5;
+}
+
+.tags-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+}
+</style>

--- a/frontend/src/views/ImagePublish.vue
+++ b/frontend/src/views/ImagePublish.vue
@@ -150,6 +150,14 @@
             @config-changed="onChannelConfigChanged"
             @publish-result="onPublishResult"
           />
+          <WeixinGzhImagePublishPanel
+            ref="weixinGzhPanelRef"
+            :account-id="selectedPlatform === 'weixin_gzh' ? selectedAccountId : null"
+            :disabled="publishing"
+            v-show="selectedPlatform === 'weixin_gzh'"
+            @config-changed="onChannelConfigChanged"
+            @publish-result="onPublishResult"
+          />
         </div>
 
         <!-- No account selected hint -->
@@ -310,6 +318,7 @@ import XiaohongshuImagePublishPanel from '@/components/xiaohongshu/ImagePublishP
 import KuaishouImagePublishPanel from '@/components/kuaishou/ImagePublishPanel.vue'
 import WeiboImagePublishPanel from '@/components/weibo/ImagePublishPanel.vue'
 import AlipayImagePublishPanel from '@/components/alipay/ImagePublishPanel.vue'
+import WeixinGzhImagePublishPanel from '@/components/weixin_gzh/ImagePublishPanel.vue'
 import PrePublishCheckDialog from '@/components/PrePublishCheckDialog.vue'
 
 // ========== Stores & Config ==========
@@ -320,7 +329,7 @@ appStore.loadAccountCheckMode()
 appStore.loadAutoSaveSettings()
 const route = useRoute()
 
-const IMAGE_PLATFORM_KEYS = ['xiaohongshu', 'douyin', 'kuaishou', 'weibo', 'alipay']
+const IMAGE_PLATFORM_KEYS = ['xiaohongshu', 'douyin', 'kuaishou', 'weibo', 'alipay', 'weixin_gzh']
 const IMAGE_PLATFORMS = platformList.filter(p => IMAGE_PLATFORM_KEYS.includes(p.key))
 
 // ========== Left Sidebar State ==========
@@ -409,9 +418,10 @@ const xiaohongshuPanelRef = ref(null)
 const kuaishouPanelRef = ref(null)
 const weiboPanelRef = ref(null)
 const alipayPanelRef = ref(null)
+const weixinGzhPanelRef = ref(null)
 
 function getPanel(key) {
-  const map = { douyin: douyinPanelRef, xiaohongshu: xiaohongshuPanelRef, kuaishou: kuaishouPanelRef, weibo: weiboPanelRef, alipay: alipayPanelRef }
+  const map = { douyin: douyinPanelRef, xiaohongshu: xiaohongshuPanelRef, kuaishou: kuaishouPanelRef, weibo: weiboPanelRef, alipay: alipayPanelRef, weixin_gzh: weixinGzhPanelRef }
   return map[key]?.value
 }
 
@@ -431,7 +441,7 @@ function onPublishResult({ accountName, status, message }) {
 function hasAccountOverride(accountId) {
   // Task 10：新增覆写层勾选 + panel 内部 accountOverrides 任一为真都算
   if (accountChecked[accountId] && hasAccountOverrideContent(accountId)) return true
-  for (const key of ['douyin', 'xiaohongshu', 'kuaishou', 'weibo', 'alipay']) {
+  for (const key of ['douyin', 'xiaohongshu', 'kuaishou', 'weibo', 'alipay', 'weixin_gzh']) {
     const panel = getPanel(key)
     if (panel && panel.hasAccountOverride(accountId)) return true
   }
@@ -500,8 +510,8 @@ function mergeConfig(common, platformDefault, platformOv, accountOv, panelAccoun
     // 媒体字段走 4 级合并 → commonConfig 兜底
     images: accountOv?.images ?? platformOv?.images ?? platformDefault?.images ?? common.images,
     coverImage: accountOv?.coverImage ?? platformOv?.coverImage ?? platformDefault?.coverImage ?? common.coverImage,
-    enableTimer: accountOv?.enableTimer ?? platformOv?.enableTimer ?? platformDefault?.enableTimer ?? 0,
-    scheduleTime: accountOv?.scheduleTime ?? platformOv?.scheduleTime ?? platformDefault?.scheduleTime ?? '',
+    enableTimer: accountOv?.enableTimer ?? panelAccountOv?.enableTimer ?? platformOv?.enableTimer ?? platformDefault?.enableTimer ?? 0,
+    scheduleTime: accountOv?.scheduleTime ?? panelAccountOv?.scheduleTime ?? platformOv?.scheduleTime ?? platformDefault?.scheduleTime ?? '',
     aiContent: accountOv?.aiContent ?? panelAccountOv?.aiContent ?? platformOv?.aiContent ?? platformDefault?.aiContent ?? '',
     isOriginal: accountOv?.isOriginal ?? platformOv?.isOriginal ?? platformDefault?.isOriginal ?? false,
     music: accountOv?.music ?? panelAccountOv?.music ?? platformOv?.music ?? platformDefault?.music ?? null,
@@ -532,6 +542,7 @@ const panelsProxy = reactive({
   get kuaishou() { return kuaishouPanelRef.value },
   get weibo() { return weiboPanelRef.value },
   get alipay() { return alipayPanelRef.value },
+  get weixin_gzh() { return weixinGzhPanelRef.value },
 })
 const { applyImageBatchSet } = useImageBatchSetApply({ panels: panelsProxy })
 // 渠道个性化可见平台列表：过滤掉被拉黑的平台
@@ -679,7 +690,7 @@ async function saveDraft() {
   try {
     const allPlatformConfigs = {}
     const panelAccountOverrides = {}
-    for (const key of ['douyin', 'xiaohongshu', 'kuaishou', 'weibo', 'alipay']) {
+    for (const key of ['douyin', 'xiaohongshu', 'kuaishou', 'weibo', 'alipay', 'weixin_gzh']) {
       const panel = getPanel(key)
       if (panel) {
         const configs = panel.getConfigs()
@@ -944,7 +955,7 @@ function handleOneClickFill(record) {
 // ========== Old Draft Migration ==========
 function migrateOldDraftFormat(dd) {
   if (dd.commonConfig?.topics && Array.isArray(dd.commonConfig.topics)) {
-    for (const key of ['douyin', 'xiaohongshu', 'kuaishou', 'weibo', 'alipay']) {
+    for (const key of ['douyin', 'xiaohongshu', 'kuaishou', 'weibo', 'alipay', 'weixin_gzh']) {
       if (dd.platformConfigs?.[key]) {
         dd.platformConfigs[key].tags = [...dd.commonConfig.topics]
       }


### PR DESCRIPTION
后端:
- WeixinGzhPlatform 新增 publish_image 三层方法:创作中心首页点「贴图」→ 新 tab(appmsg_edit_v2 type=77)→ 多图上传 → 复用视频 helpers 填标题/描述/ 合集/创作来源/发表(含定时)。_fill_publish_title 加图集 ProseMirror 分支 (图集 textarea 隐藏,真正可编辑的是 .title-editor-overlay .ProseMirror)
- _fill_publish_title/_fill_description 加 max_len 参数(图集 20/1000, 视频 64/300)
- image_publish_bp platform_map 补 weixin_gzh:17 + publish_kwargs 补 gzh 字段
- weixin_gzh_bp 合集抓取支持 collection_type 参数(视频合集/贴图合集), 找不到 tab 返回空列表(无该类型合集)

前端:
- 新建 components/weixin_gzh/ImagePublishPanel.vue(标题≤20/描述≤1000/标签/ 创作来源/贴图合集/定时发布)
- api/weixin_gzh.js getCollections 支持 collectionType 参数
- ImagePublish.vue 注册公众号图集面板 + 全部枚举点
- 修复 ImagePublish.vue mergeConfig 的 scheduleTime/enableTimer 合并: 补上 panelAccountOv(之前漏了导致账号级设定时时间在发布时被清空)